### PR TITLE
feat: per-backend health detail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +268,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -845,6 +868,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1240,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "clap",
  "metrics",
  "metrics-exporter-prometheus",
@@ -3153,10 +3201,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.29"
 tracing-opentelemetry = "0.30"
+chrono = { version = "0.4", features = ["serde"] }
 moka = { version = "0.12.14", features = ["future"] }
 notify = { version = "7", default-features = false, features = ["macos_fsevent"] }
 notify-debouncer-mini = "0.5"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides endpoints for checking backend health and gateway status.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,6 +10,7 @@ use axum::Router;
 use axum::extract::Extension;
 use axum::response::{IntoResponse, Json};
 use axum::routing::get;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::RwLock;
 use tower_mcp::SessionHandle;
@@ -49,6 +51,10 @@ impl AdminState {
 pub struct BackendStatus {
     pub namespace: String,
     pub healthy: bool,
+    pub last_checked_at: Option<DateTime<Utc>>,
+    pub consecutive_failures: u32,
+    pub error: Option<String>,
+    pub transport: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -65,6 +71,12 @@ struct GatewayInfo {
     active_sessions: usize,
 }
 
+/// Per-backend metadata passed in from config at startup.
+#[derive(Clone)]
+pub struct BackendMeta {
+    pub transport: String,
+}
+
 /// Spawn a background task that periodically health-checks backends.
 /// Returns the AdminState that admin endpoints read from.
 pub fn spawn_health_checker(
@@ -72,6 +84,7 @@ pub fn spawn_health_checker(
     gateway_name: String,
     gateway_version: String,
     backend_count: usize,
+    backend_meta: HashMap<String, BackendMeta>,
 ) -> AdminState {
     let health: Arc<RwLock<Vec<BackendStatus>>> = Arc::new(RwLock::new(Vec::new()));
     let health_writer = Arc::clone(&health);
@@ -85,14 +98,36 @@ pub fn spawn_health_checker(
             .enable_all()
             .build()
             .expect("admin health check runtime");
+
+        // Track consecutive failure counts across check cycles.
+        let mut failure_counts: HashMap<String, u32> = HashMap::new();
+
         rt.block_on(async move {
             loop {
                 let results = proxy.health_check().await;
+                let now = Utc::now();
                 let statuses: Vec<BackendStatus> = results
                     .into_iter()
-                    .map(|h| BackendStatus {
-                        namespace: h.namespace,
-                        healthy: h.healthy,
+                    .map(|h| {
+                        let count = failure_counts.entry(h.namespace.clone()).or_insert(0);
+                        if h.healthy {
+                            *count = 0;
+                        } else {
+                            *count += 1;
+                        }
+                        let meta = backend_meta.get(&h.namespace);
+                        BackendStatus {
+                            namespace: h.namespace,
+                            healthy: h.healthy,
+                            last_checked_at: Some(now),
+                            consecutive_failures: *count,
+                            error: if h.healthy {
+                                None
+                            } else {
+                                Some("ping failed".to_string())
+                            },
+                            transport: meta.map(|m| m.transport.clone()),
+                        }
                     })
                     .collect();
                 *health_writer.write().await = statuses;
@@ -127,6 +162,26 @@ async fn handle_backends(
     })
 }
 
+async fn handle_health(Extension(state): Extension<AdminState>) -> Json<HealthResponse> {
+    let backends = state.health.read().await;
+    let all_healthy = backends.iter().all(|b| b.healthy);
+    let unhealthy: Vec<String> = backends
+        .iter()
+        .filter(|b| !b.healthy)
+        .map(|b| b.namespace.clone())
+        .collect();
+    Json(HealthResponse {
+        status: if all_healthy { "healthy" } else { "degraded" }.to_string(),
+        unhealthy_backends: unhealthy,
+    })
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    unhealthy_backends: Vec<String>,
+}
+
 async fn handle_metrics(
     Extension(handle): Extension<Option<metrics_exporter_prometheus::PrometheusHandle>>,
 ) -> impl IntoResponse {
@@ -144,6 +199,7 @@ pub fn admin_router(
 ) -> Router {
     Router::new()
         .route("/backends", get(handle_backends))
+        .route("/health", get(handle_health))
         .route("/metrics", get(handle_metrics))
         .layer(Extension(state))
         .layer(Extension(metrics_handle))

--- a/src/admin_tools.rs
+++ b/src/admin_tools.rs
@@ -26,6 +26,13 @@ struct AdminToolState {
 struct BackendInfo {
     namespace: String,
     healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_checked_at: Option<String>,
+    consecutive_failures: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -81,6 +88,10 @@ fn build_admin_router(state: AdminToolState) -> McpRouter {
                     .map(|b| BackendInfo {
                         namespace: b.namespace.clone(),
                         healthy: b.healthy,
+                        last_checked_at: b.last_checked_at.map(|t| t.to_rfc3339()),
+                        consecutive_failures: b.consecutive_failures,
+                        error: b.error.clone(),
+                        transport: b.transport.clone(),
                     })
                     .collect();
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -14,6 +14,7 @@ use tower_mcp::client::StdioClientTransport;
 use tower_mcp::proxy::McpProxy;
 use tower_mcp::{RouterRequest, RouterResponse};
 
+use crate::admin::BackendMeta;
 use crate::alias;
 use crate::cache;
 use crate::coalesce;
@@ -63,12 +64,27 @@ impl Gateway {
         // Inbound authentication (axum-level middleware)
         let router = apply_auth(&config, router).await?;
 
+        // Collect backend metadata for the health checker
+        let backend_meta: std::collections::HashMap<String, BackendMeta> = config
+            .backends
+            .iter()
+            .map(|b| {
+                (
+                    b.name.clone(),
+                    BackendMeta {
+                        transport: format!("{:?}", b.transport).to_lowercase(),
+                    },
+                )
+            })
+            .collect();
+
         // Admin API
         let admin_state = crate::admin::spawn_health_checker(
             proxy_for_admin,
             config.gateway.name.clone(),
             config.gateway.version.clone(),
             config.backends.len(),
+            backend_meta,
         );
         let router = router.nest(
             "/admin",


### PR DESCRIPTION
## Summary
- Enriched `BackendStatus` with `last_checked_at`, `consecutive_failures`, `error`, and `transport` fields
- Added `/admin/health` liveness endpoint returning `healthy`/`degraded` status with list of unhealthy backends
- Health checker now tracks consecutive failure counts across check cycles
- Admin tools `list_backends` response includes all enriched health data

## Test plan
- [x] All 46 unit tests pass
- [x] All 8 integration tests pass
- [x] clippy clean, fmt clean

Closes #3