### PR TITLE
docs: add doc tests for public API

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -58,6 +58,9 @@ impl CacheStats {
 }
 
 /// Snapshot of cache statistics for a single backend.
+///
+/// Returned by [`CacheHandle::stats()`] to report hit/miss rates
+/// and entry counts per cached namespace.
 #[derive(Serialize, Clone)]
 pub struct CacheStatsSnapshot {
     pub namespace: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,6 +343,24 @@ pub enum NameFilter {
 }
 
 impl NameFilter {
+    /// Check if a capability name is allowed by this filter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use mcp_gateway::config::NameFilter;
+    ///
+    /// let filter = NameFilter::DenyList(["delete".to_string()].into());
+    /// assert!(filter.allows("read"));
+    /// assert!(!filter.allows("delete"));
+    ///
+    /// let filter = NameFilter::AllowList(["read".to_string()].into());
+    /// assert!(filter.allows("read"));
+    /// assert!(!filter.allows("write"));
+    ///
+    /// assert!(NameFilter::PassAll.allows("anything"));
+    /// ```
     pub fn allows(&self, name: &str) -> bool {
         match self {
             Self::PassAll => true,
@@ -407,6 +425,26 @@ impl GatewayConfig {
     }
 
     /// Parse and validate a config from a TOML string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_gateway::GatewayConfig;
+    ///
+    /// let config = GatewayConfig::parse(r#"
+    ///     [gateway]
+    ///     name = "my-gateway"
+    ///     [gateway.listen]
+    ///
+    ///     [[backends]]
+    ///     name = "echo"
+    ///     transport = "stdio"
+    ///     command = "echo"
+    /// "#).unwrap();
+    ///
+    /// assert_eq!(config.gateway.name, "my-gateway");
+    /// assert_eq!(config.backends.len(), 1);
+    /// ```
     pub fn parse(toml: &str) -> Result<Self> {
         let config: Self = toml::from_str(toml).context("parsing config")?;
         config.validate()?;


### PR DESCRIPTION
## Summary
- Add runnable doc tests for `GatewayConfig::parse` and `NameFilter::allows`
- Improve doc comment on `CacheStatsSnapshot`
- `cargo test --doc` now runs 3 tests (up from 1)

## Test plan
- [x] `cargo test --doc --all-features` passes (3 passed, 1 ignored)
- [x] `cargo doc --no-deps` builds without warnings

Closes #20