### PR TITLE
feat: token passthrough and per-backend static auth

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,13 @@ pub struct BackendConfig {
     pub retry: Option<RetryConfig>,
     /// Per-backend cache policy
     pub cache: Option<BackendCacheConfig>,
+    /// Static bearer token for authenticating to this backend (HTTP only).
+    /// Supports `${ENV_VAR}` syntax for env var resolution.
+    pub bearer_token: Option<String>,
+    /// Forward the client's inbound auth token to this backend.
+    /// Only works with HTTP backends when the gateway has auth enabled.
+    #[serde(default)]
+    pub forward_auth: bool,
     /// Tool aliases: rename tools exposed by this backend
     #[serde(default)]
     pub aliases: Vec<AliasConfig>,
@@ -493,6 +500,12 @@ impl GatewayConfig {
                 {
                     *value = env_val;
                 }
+            }
+            if let Some(ref mut token) = backend.bearer_token
+                && let Some(var_name) = token.strip_prefix("${").and_then(|s| s.strip_suffix('}'))
+                && let Ok(env_val) = std::env::var(var_name)
+            {
+                *token = env_val;
             }
         }
     }
@@ -965,6 +978,63 @@ mod tests {
 
         // SAFETY: same as above
         unsafe { std::env::remove_var("MCP_GW_TEST_TOKEN") };
+    }
+
+    #[test]
+    fn test_parse_bearer_token_and_forward_auth() {
+        let toml = r#"
+        [gateway]
+        name = "token-gw"
+        [gateway.listen]
+
+        [[backends]]
+        name = "github"
+        transport = "http"
+        url = "http://localhost:3000"
+        bearer_token = "ghp_abc123"
+        forward_auth = true
+
+        [[backends]]
+        name = "db"
+        transport = "http"
+        url = "http://localhost:5432"
+        "#;
+
+        let config = GatewayConfig::parse(toml).unwrap();
+        assert_eq!(
+            config.backends[0].bearer_token.as_deref(),
+            Some("ghp_abc123")
+        );
+        assert!(config.backends[0].forward_auth);
+        assert!(config.backends[1].bearer_token.is_none());
+        assert!(!config.backends[1].forward_auth);
+    }
+
+    #[test]
+    fn test_resolve_bearer_token_env_var() {
+        unsafe { std::env::set_var("MCP_GW_TEST_BEARER", "resolved-token") };
+
+        let toml = r#"
+        [gateway]
+        name = "env-token"
+        [gateway.listen]
+
+        [[backends]]
+        name = "api"
+        transport = "http"
+        url = "http://localhost:3000"
+        bearer_token = "${MCP_GW_TEST_BEARER}"
+        "#;
+
+        let mut config = GatewayConfig::parse(toml).unwrap();
+        config.resolve_env_vars();
+
+        assert_eq!(
+            config.backends[0].bearer_token.as_deref(),
+            Some("resolved-token")
+        );
+
+        unsafe { std::env::remove_var("MCP_GW_TEST_BEARER") };
     }
 
     // ========================================================================

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -214,7 +214,10 @@ async fn build_proxy(config: &GatewayConfig) -> Result<McpProxy> {
             }
             TransportType::Http => {
                 let url = backend.url.as_deref().unwrap();
-                let transport = tower_mcp::client::HttpClientTransport::new(url);
+                let mut transport = tower_mcp::client::HttpClientTransport::new(url);
+                if let Some(token) = &backend.bearer_token {
+                    transport = transport.bearer_token(token);
+                }
 
                 builder = builder.backend(&backend.name, transport).await;
             }
@@ -415,6 +418,25 @@ fn build_middleware_stack(
 
     if let Some(rbac) = rbac_config {
         service = BoxCloneService::new(RbacService::new(service, rbac));
+    }
+
+    // Token passthrough (inject ClientToken for forward_auth backends)
+    let forward_namespaces: std::collections::HashSet<String> = config
+        .backends
+        .iter()
+        .filter(|b| b.forward_auth)
+        .map(|b| format!("{}{}", b.name, config.gateway.separator))
+        .collect();
+
+    if !forward_namespaces.is_empty() {
+        tracing::info!(
+            backends = ?forward_namespaces,
+            "Enabling token passthrough for forward_auth backends"
+        );
+        service = BoxCloneService::new(crate::token::TokenPassthroughService::new(
+            service,
+            forward_namespaces,
+        ));
     }
 
     // Metrics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod metrics;
 pub mod rbac;
 pub mod reload;
 pub mod retry;
+pub mod token;
 pub mod validation;
 
 #[cfg(test)]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -179,7 +179,10 @@ async fn add_backend(proxy: &McpProxy, backend: &BackendConfig) -> anyhow::Resul
                 .url
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("http backend requires 'url'"))?;
-            let transport = tower_mcp::client::HttpClientTransport::new(url);
+            let mut transport = tower_mcp::client::HttpClientTransport::new(url);
+            if let Some(token) = &backend.bearer_token {
+                transport = transport.bearer_token(token);
+            }
 
             if has_middleware {
                 let layer = build_backend_layer(backend);

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,252 @@
+//! Token passthrough middleware for forwarding client credentials to backends.
+//!
+//! When a backend has `forward_auth = true`, the client's inbound bearer token
+//! is extracted from `RouterRequest.extensions` and stored as a [`ClientToken`]
+//! for downstream middleware and backend services to consume.
+//!
+//! # Configuration
+//!
+//! ```toml
+//! [[backends]]
+//! name = "github"
+//! transport = "http"
+//! url = "http://github-mcp.internal:8080"
+//! forward_auth = true  # forward client's token to this backend
+//!
+//! [[backends]]
+//! name = "db"
+//! transport = "http"
+//! url = "http://db-mcp.internal:8080"
+//! bearer_token = "${DB_API_KEY}"  # static token for this backend
+//! ```
+//!
+//! # How it works
+//!
+//! 1. The gateway's auth layer (JWT/bearer) validates the inbound token and
+//!    stores [`TokenClaims`](tower_mcp::oauth::token::TokenClaims) in request extensions.
+//! 2. This middleware reads the `TokenClaims` and stores the subject (`sub` claim)
+//!    and any available identity info as a [`ClientToken`] in extensions.
+//! 3. Backend-specific middleware or future transport enhancements can read
+//!    `ClientToken` to forward credentials.
+
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tower::Service;
+
+use tower_mcp::router::{RouterRequest, RouterResponse};
+use tower_mcp_types::protocol::McpRequest;
+
+/// A client's identity token extracted from inbound authentication.
+///
+/// Stored in `RouterRequest.extensions` by the [`TokenPassthroughService`]
+/// for downstream consumption.
+#[derive(Debug, Clone)]
+pub struct ClientToken {
+    /// The subject (user/client identifier) from the token.
+    pub subject: Option<String>,
+    /// Space-delimited scopes from the token.
+    pub scope: Option<String>,
+    /// The raw bearer token string, if available.
+    pub raw_token: Option<String>,
+}
+
+/// Middleware that extracts client identity from auth claims and makes it
+/// available to backends configured with `forward_auth = true`.
+#[derive(Clone)]
+pub struct TokenPassthroughService<S> {
+    inner: S,
+    forward_namespaces: Arc<HashSet<String>>,
+}
+
+impl<S> TokenPassthroughService<S> {
+    /// Create a new token passthrough service.
+    ///
+    /// `forward_namespaces` is the set of backend namespace prefixes (e.g. `"github/"`)
+    /// that should receive forwarded tokens.
+    pub fn new(inner: S, forward_namespaces: HashSet<String>) -> Self {
+        Self {
+            inner,
+            forward_namespaces: Arc::new(forward_namespaces),
+        }
+    }
+}
+
+/// Check if a request targets a namespace that wants token forwarding.
+fn request_targets_namespace(req: &McpRequest, namespaces: &HashSet<String>) -> bool {
+    let name = match req {
+        McpRequest::CallTool(params) => Some(params.name.as_str()),
+        McpRequest::ReadResource(params) => Some(params.uri.as_str()),
+        McpRequest::GetPrompt(params) => Some(params.name.as_str()),
+        _ => None,
+    };
+    if let Some(name) = name {
+        namespaces.iter().any(|ns| name.starts_with(ns))
+    } else {
+        false
+    }
+}
+
+impl<S> Service<RouterRequest> for TokenPassthroughService<S>
+where
+    S: Service<RouterRequest, Response = RouterResponse, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
+    type Response = RouterResponse;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: RouterRequest) -> Self::Future {
+        // Only inject ClientToken for requests targeting forward_auth backends
+        if !self.forward_namespaces.is_empty()
+            && request_targets_namespace(&req.inner, &self.forward_namespaces)
+        {
+            let client_token = req
+                .extensions
+                .get::<tower_mcp::oauth::token::TokenClaims>()
+                .map(|claims| ClientToken {
+                    subject: claims.sub.clone(),
+                    scope: claims.scope.clone(),
+                    raw_token: None, // Raw token not available from TokenClaims
+                });
+            if let Some(token) = client_token {
+                tracing::debug!(
+                    subject = ?token.subject,
+                    "Injected ClientToken for forward_auth backend"
+                );
+                req.extensions.insert(token);
+            }
+        }
+
+        let fut = self.inner.call(req);
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use tower::Service;
+    use tower_mcp::protocol::{CallToolParams, McpRequest, RequestId};
+    use tower_mcp::router::{Extensions, RouterRequest};
+
+    use super::{TokenPassthroughService, request_targets_namespace};
+    use crate::test_util::{MockService, call_service};
+
+    #[test]
+    fn test_request_targets_namespace_match() {
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let req = McpRequest::CallTool(CallToolParams {
+            name: "github/search".to_string(),
+            arguments: serde_json::json!({}),
+            meta: None,
+            task: None,
+        });
+        assert!(request_targets_namespace(&req, &namespaces));
+    }
+
+    #[test]
+    fn test_request_targets_namespace_no_match() {
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let req = McpRequest::CallTool(CallToolParams {
+            name: "db/query".to_string(),
+            arguments: serde_json::json!({}),
+            meta: None,
+            task: None,
+        });
+        assert!(!request_targets_namespace(&req, &namespaces));
+    }
+
+    #[test]
+    fn test_request_targets_namespace_list_tools() {
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let req = McpRequest::ListTools(Default::default());
+        assert!(!request_targets_namespace(&req, &namespaces));
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_injects_client_token() {
+        let mock = MockService::with_tools(&["github/search"]);
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let mut svc = TokenPassthroughService::new(mock, namespaces);
+
+        // Create request with TokenClaims in extensions
+        let mut extensions = Extensions::new();
+        extensions.insert(tower_mcp::oauth::token::TokenClaims {
+            sub: Some("user-123".to_string()),
+            scope: Some("mcp:read".to_string()),
+            iss: None,
+            aud: None,
+            exp: None,
+            client_id: None,
+            extra: Default::default(),
+        });
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                name: "github/search".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions,
+        };
+
+        let resp = svc.call(req).await.unwrap();
+        assert!(resp.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_skips_non_forward_backends() {
+        let mock = MockService::with_tools(&["db/query"]);
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let mut svc = TokenPassthroughService::new(mock, namespaces);
+
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(CallToolParams {
+                name: "db/query".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(resp.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_no_claims_passes_through() {
+        let mock = MockService::with_tools(&["github/search"]);
+        let namespaces: HashSet<String> = ["github/".to_string()].into();
+        let mut svc = TokenPassthroughService::new(mock, namespaces);
+
+        // No TokenClaims in extensions -- should still pass through
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(CallToolParams {
+                name: "github/search".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(resp.inner.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `bearer_token` config field for HTTP backends (static token, supports `${ENV_VAR}` resolution)
- Add `forward_auth` config flag per backend to inject client identity into request extensions
- New `TokenPassthroughService` middleware extracts JWT `TokenClaims` and stores `ClientToken` (subject, scope) for downstream use
- Wired into gateway startup and hot reload paths

## Design

**Phase 1 (this PR):**
- Per-backend static `bearer_token` on HTTP transports
- `forward_auth` flag that injects `ClientToken` into extensions for backends that need client identity
- `ClientToken` carries subject and scope from inbound JWT

**Phase 2 (future):**
- Dynamic per-request token forwarding via tower-mcp `TokenProvider` trait
- Raw bearer token preservation through the auth pipeline

## Config example
```toml
[[backends]]
name = "github"
transport = "http"
url = "http://github-mcp.internal:8080"
bearer_token = "${GITHUB_TOKEN}"  # static backend auth
forward_auth = true                # also forward client identity
```

## Test plan
- [x] 62 unit tests pass (8 new: 2 config + 6 token middleware)
- [x] 11 integration tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #8