### PR TITLE
feat: request hedging via tower-resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,6 +2748,7 @@ checksum = "315d54ec46180f44a269c1870a7f6f00fd9f5fc3218666265425f071991a2fa4"
 dependencies = [
  "tower-resilience-circuitbreaker",
  "tower-resilience-core",
+ "tower-resilience-hedge",
  "tower-resilience-ratelimiter",
 ]
 
@@ -2772,6 +2773,21 @@ checksum = "d6f8718d3121ee3463d8ddb7a8bffcc76e42f2259c8e4e6cc09926c52ad8cabf"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tower-resilience-hedge"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98bf07e224f5b6fedc46d961b73aac237fb8d172e80c6b9cc4758985fa3ae162"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-resilience-core",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tower-mcp = { version = "0.8.3", features = ["http", "http-client", "proxy", "oa
 tower-mcp-types = "0.8.3"
 axum = "0.8"
 tower = { version = "0.5", features = ["util", "timeout", "limit", "retry"] }
-tower-resilience = { version = "0.8", default-features = false, features = ["circuitbreaker", "ratelimiter"] }
+tower-resilience = { version = "0.8", default-features = false, features = ["circuitbreaker", "ratelimiter", "hedge"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct BackendConfig {
     pub retry: Option<RetryConfig>,
     /// Per-backend outlier detection (passive health checks)
     pub outlier_detection: Option<OutlierDetectionConfig>,
+    /// Per-backend request hedging (parallel redundant requests)
+    pub hedging: Option<HedgingConfig>,
     /// Mirror traffic from another backend (fire-and-forget).
     /// Set to the name of the source backend to mirror.
     pub mirror_of: Option<String>,
@@ -190,6 +192,22 @@ pub struct OutlierDetectionConfig {
     /// Maximum percentage of backends that can be ejected (default: 50)
     #[serde(default = "default_max_ejection_percent")]
     pub max_ejection_percent: u32,
+}
+
+/// Request hedging configuration.
+///
+/// Sends parallel redundant requests to reduce tail latency. If the primary
+/// request hasn't completed after `delay_ms`, a hedge request is fired.
+/// The first successful response wins.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HedgingConfig {
+    /// Delay in milliseconds before sending a hedge request (default: 200).
+    /// Set to 0 for parallel mode (all requests fire immediately).
+    #[serde(default = "default_hedge_delay_ms")]
+    pub delay_ms: u64,
+    /// Maximum number of additional hedge requests (default: 1)
+    #[serde(default = "default_max_hedges")]
+    pub max_hedges: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -367,6 +385,14 @@ fn default_base_ejection_seconds() -> u64 {
 
 fn default_max_ejection_percent() -> u32 {
     50
+}
+
+fn default_hedge_delay_ms() -> u64 {
+    200
+}
+
+fn default_max_hedges() -> usize {
+    1
 }
 
 fn default_mirror_percent() -> u32 {
@@ -1301,6 +1327,56 @@ mod tests {
             format!("{err}").contains("mirror_of cannot reference itself"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_parse_hedging_config() {
+        let toml = r#"
+        [gateway]
+        name = "hedge-gw"
+        [gateway.listen]
+
+        [[backends]]
+        name = "api"
+        transport = "http"
+        url = "http://localhost:8080"
+
+        [backends.hedging]
+        delay_ms = 150
+        max_hedges = 2
+        "#;
+
+        let config = GatewayConfig::parse(toml).unwrap();
+        let hedge = config.backends[0]
+            .hedging
+            .as_ref()
+            .expect("should have hedging");
+        assert_eq!(hedge.delay_ms, 150);
+        assert_eq!(hedge.max_hedges, 2);
+    }
+
+    #[test]
+    fn test_parse_hedging_defaults() {
+        let toml = r#"
+        [gateway]
+        name = "hedge-gw"
+        [gateway.listen]
+
+        [[backends]]
+        name = "api"
+        transport = "http"
+        url = "http://localhost:8080"
+
+        [backends.hedging]
+        "#;
+
+        let config = GatewayConfig::parse(toml).unwrap();
+        let hedge = config.backends[0]
+            .hedging
+            .as_ref()
+            .expect("should have hedging");
+        assert_eq!(hedge.delay_ms, 200);
+        assert_eq!(hedge.max_hedges, 1);
     }
 
     // ========================================================================

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -250,6 +250,32 @@ async fn build_proxy(config: &GatewayConfig) -> Result<McpProxy> {
             builder = builder.backend_layer(tower::retry::RetryLayer::new(policy));
         }
 
+        // Hedging (after retry, before concurrency -- hedges are separate requests)
+        if let Some(hedge_cfg) = &backend.hedging {
+            let delay = Duration::from_millis(hedge_cfg.delay_ms);
+            let max_attempts = hedge_cfg.max_hedges + 1; // +1 for the primary request
+            tracing::info!(
+                backend = %backend.name,
+                delay_ms = hedge_cfg.delay_ms,
+                max_hedges = hedge_cfg.max_hedges,
+                "Applying request hedging"
+            );
+            let layer = if delay.is_zero() {
+                tower_resilience::hedge::HedgeLayer::builder()
+                    .no_delay()
+                    .max_hedged_attempts(max_attempts)
+                    .name(format!("{}-hedge", backend.name))
+                    .build()
+            } else {
+                tower_resilience::hedge::HedgeLayer::builder()
+                    .delay(delay)
+                    .max_hedged_attempts(max_attempts)
+                    .name(format!("{}-hedge", backend.name))
+                    .build()
+            };
+            builder = builder.backend_layer(layer);
+        }
+
         // Concurrency limit
         if let Some(cc) = &backend.concurrency {
             tracing::info!(

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -143,6 +143,7 @@ async fn add_backend(proxy: &McpProxy, backend: &BackendConfig) -> anyhow::Resul
         || backend.rate_limit.is_some()
         || backend.concurrency.is_some()
         || backend.retry.is_some()
+        || backend.hedging.is_some()
         || backend.outlier_detection.is_some();
 
     match backend.transport {
@@ -252,6 +253,7 @@ fn build_backend_layer(backend: &BackendConfig) -> BackendMiddlewareLayer {
             cb.permitted_calls_in_half_open,
         )
     });
+    let hedging = backend.hedging.clone();
     let outlier = backend.outlier_detection.clone();
     let name = backend.name.clone();
 
@@ -265,6 +267,27 @@ fn build_backend_layer(backend: &BackendConfig) -> BackendMiddlewareLayer {
                 let policy = crate::retry::McpRetryPolicy::from_config(retry_cfg);
                 let retried = tower::Layer::layer(&tower::retry::RetryLayer::new(policy), svc);
                 svc = BoxCloneService::new(tower_mcp::CatchError::new(retried));
+            }
+
+            // Hedging
+            if let Some(ref hedge_cfg) = hedging {
+                let delay = Duration::from_millis(hedge_cfg.delay_ms);
+                let max_attempts = hedge_cfg.max_hedges + 1;
+                let layer = if delay.is_zero() {
+                    tower_resilience::hedge::HedgeLayer::builder()
+                        .no_delay()
+                        .max_hedged_attempts(max_attempts)
+                        .name(format!("{}-hedge", name))
+                        .build()
+                } else {
+                    tower_resilience::hedge::HedgeLayer::builder()
+                        .delay(delay)
+                        .max_hedged_attempts(max_attempts)
+                        .name(format!("{}-hedge", name))
+                        .build()
+                };
+                let hedged = tower::Layer::layer(&layer, svc);
+                svc = BoxCloneService::new(tower_mcp::CatchError::new(hedged));
             }
 
             // Concurrency limit


### PR DESCRIPTION
## Summary

- Add per-backend request hedging using tower-resilience's `HedgeLayer`
- Sends parallel redundant requests to reduce tail latency
- If the primary request hasn't responded after `delay_ms`, a hedge request fires
- First successful response wins; other in-flight requests are cancelled
- Supports parallel mode (`delay_ms = 0`) for immediate fan-out

Uses tower-resilience's hedge module directly (same pattern as circuit breaker and rate limiter) -- no custom implementation needed.

## Configuration

```toml
[backends.hedging]
delay_ms = 200    # send hedge after 200ms if no response (default)
max_hedges = 1    # at most 1 additional request (default)
```

Parallel mode (fire all requests immediately):
```toml
[backends.hedging]
delay_ms = 0
max_hedges = 2    # 3 total requests (1 primary + 2 hedges)
```

## Changes

- `Cargo.toml`: Added `hedge` feature to tower-resilience dependency
- `src/config.rs`: `HedgingConfig` struct with `delay_ms` and `max_hedges`
- `src/gateway.rs`: Wire `HedgeLayer` into per-backend middleware stack (after retry, before concurrency limit)
- `src/reload.rs`: Support for hot-reloaded backends
- 2 new config parsing tests (95 total)

## Test plan

- [x] Config parsing with explicit values
- [x] Config parsing with defaults (delay_ms=200, max_hedges=1)
- [x] `cargo clippy`, `cargo test`, `cargo test --doc` all pass

Closes #31