### PR TITLE
docs: complete public API documentation

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -47,13 +47,20 @@ impl AdminState {
     }
 }
 
+/// Health status of a single backend, updated by the background health checker.
 #[derive(Serialize, Clone)]
 pub struct BackendStatus {
+    /// Backend namespace (e.g. "db/").
     pub namespace: String,
+    /// Whether the backend responded to the last health check.
     pub healthy: bool,
+    /// Timestamp of the last health check.
     pub last_checked_at: Option<DateTime<Utc>>,
+    /// Number of consecutive failed health checks.
     pub consecutive_failures: u32,
+    /// Last error message from a failed health check.
     pub error: Option<String>,
+    /// Transport type (e.g. "stdio", "http").
     pub transport: Option<String>,
 }
 
@@ -74,6 +81,7 @@ struct GatewayInfo {
 /// Per-backend metadata passed in from config at startup.
 #[derive(Clone)]
 pub struct BackendMeta {
+    /// Transport type string (e.g. "stdio", "http").
     pub transport: String,
 }
 

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -24,6 +24,7 @@ pub struct AliasMap {
 }
 
 impl AliasMap {
+    /// Build an alias map from `(namespace, from, to)` triples. Returns `None` if empty.
     pub fn new(mappings: Vec<(String, String, String)>) -> Option<Self> {
         if mappings.is_empty() {
             return None;
@@ -48,6 +49,7 @@ pub struct AliasService<S> {
 }
 
 impl<S> AliasService<S> {
+    /// Create a new alias service wrapping `inner` with the given alias map.
     pub fn new(inner: S, aliases: AliasMap) -> Self {
         Self {
             inner,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -63,10 +63,15 @@ impl CacheStats {
 /// and entry counts per cached namespace.
 #[derive(Serialize, Clone)]
 pub struct CacheStatsSnapshot {
+    /// Backend namespace this cache covers.
     pub namespace: String,
+    /// Total cache hits.
     pub hits: u64,
+    /// Total cache misses.
     pub misses: u64,
+    /// Hit rate as a fraction (0.0-1.0).
     pub hit_rate: f64,
+    /// Current number of cached entries.
     pub entry_count: u64,
 }
 

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -24,6 +24,7 @@ pub struct CoalesceService<S> {
 }
 
 impl<S> CoalesceService<S> {
+    /// Create a new request coalescing service wrapping `inner`.
     pub fn new(inner: S) -> Self {
         Self {
             inner,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+//! Gateway configuration types and TOML parsing.
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
@@ -5,28 +7,41 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+/// Top-level gateway configuration, typically loaded from a TOML file.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GatewayConfig {
+    /// Core gateway settings (name, version, listen address).
     pub gateway: Gateway,
+    /// Backend MCP servers to proxy.
     #[serde(default)]
     pub backends: Vec<BackendConfig>,
+    /// Inbound authentication configuration.
     pub auth: Option<AuthConfig>,
+    /// Performance tuning options.
     #[serde(default)]
     pub performance: PerformanceConfig,
+    /// Security policies.
     #[serde(default)]
     pub security: SecurityConfig,
+    /// Logging, metrics, and tracing configuration.
     #[serde(default)]
     pub observability: ObservabilityConfig,
 }
 
+/// Core gateway identity and server settings.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Gateway {
+    /// Gateway name, used in MCP server info.
     pub name: String,
+    /// Gateway version, used in MCP server info (default: "0.1.0").
     #[serde(default = "default_version")]
     pub version: String,
+    /// Namespace separator between backend name and tool/resource name (default: "/").
     #[serde(default = "default_separator")]
     pub separator: String,
+    /// HTTP listen address.
     pub listen: ListenConfig,
+    /// Optional instructions text sent to MCP clients.
     pub instructions: Option<String>,
     /// Graceful shutdown timeout in seconds (default: 30)
     #[serde(default = "default_shutdown_timeout")]
@@ -36,17 +51,23 @@ pub struct Gateway {
     pub hot_reload: bool,
 }
 
+/// HTTP server listen address.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ListenConfig {
+    /// Bind host (default: "127.0.0.1").
     #[serde(default = "default_host")]
     pub host: String,
+    /// Bind port (default: 8080).
     #[serde(default = "default_port")]
     pub port: u16,
 }
 
+/// Configuration for a single backend MCP server.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BackendConfig {
+    /// Unique backend name, used as the namespace prefix for its tools/resources.
     pub name: String,
+    /// Transport protocol to use when connecting to this backend.
     pub transport: TransportType,
     /// Command for stdio backends
     pub command: Option<String>,
@@ -117,18 +138,24 @@ pub struct BackendConfig {
     pub hide_prompts: Vec<String>,
 }
 
+/// Backend transport protocol.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TransportType {
+    /// Subprocess communicating via stdin/stdout.
     Stdio,
+    /// HTTP+SSE remote server.
     Http,
 }
 
+/// Per-backend request timeout.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TimeoutConfig {
+    /// Timeout duration in seconds.
     pub seconds: u64,
 }
 
+/// Per-backend circuit breaker configuration.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CircuitBreakerConfig {
     /// Failure rate threshold (0.0-1.0) to trip open (default: 0.5)
@@ -145,6 +172,7 @@ pub struct CircuitBreakerConfig {
     pub permitted_calls_in_half_open: usize,
 }
 
+/// Per-backend rate limiting configuration.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RateLimitConfig {
     /// Maximum requests per period
@@ -154,12 +182,14 @@ pub struct RateLimitConfig {
     pub period_seconds: u64,
 }
 
+/// Per-backend concurrency limit configuration.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConcurrencyConfig {
-    /// Maximum concurrent requests
+    /// Maximum concurrent requests.
     pub max_concurrent: usize,
 }
 
+/// Per-backend retry policy with exponential backoff.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts (default: 3)
@@ -230,15 +260,22 @@ pub struct HedgingConfig {
     pub max_hedges: usize,
 }
 
+/// Inbound authentication configuration.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum AuthConfig {
+    /// Static bearer token authentication.
     Bearer {
+        /// Accepted bearer tokens.
         tokens: Vec<String>,
     },
+    /// JWT authentication via JWKS endpoint.
     Jwt {
+        /// Expected token issuer (`iss` claim).
         issuer: String,
+        /// Expected token audience (`aud` claim).
         audience: String,
+        /// URL to fetch the JSON Web Key Set for token verification.
         jwks_uri: String,
         /// RBAC role definitions
         #[serde(default)]
@@ -248,8 +285,10 @@ pub enum AuthConfig {
     },
 }
 
+/// RBAC role definition.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RoleConfig {
+    /// Role name, referenced by `RoleMappingConfig`.
     pub name: String,
     /// Tools this role can access (namespaced, e.g. "files/read_file")
     #[serde(default)]
@@ -259,6 +298,7 @@ pub struct RoleConfig {
     pub deny_tools: Vec<String>,
 }
 
+/// Maps JWT claim values to RBAC role names.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RoleMappingConfig {
     /// JWT claim to read for role resolution (e.g. "scope", "role", "groups")
@@ -267,6 +307,7 @@ pub struct RoleMappingConfig {
     pub mapping: HashMap<String, String>,
 }
 
+/// Tool alias: exposes a backend tool under a different name.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AliasConfig {
     /// Original tool name (backend-local, without namespace prefix)
@@ -275,6 +316,7 @@ pub struct AliasConfig {
     pub to: String,
 }
 
+/// Per-backend response cache configuration.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BackendCacheConfig {
     /// TTL for cached resource reads in seconds (0 = disabled)
@@ -288,6 +330,7 @@ pub struct BackendCacheConfig {
     pub max_entries: u64,
 }
 
+/// Performance tuning options.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PerformanceConfig {
     /// Deduplicate identical concurrent tool calls and resource reads
@@ -295,34 +338,45 @@ pub struct PerformanceConfig {
     pub coalesce_requests: bool,
 }
 
+/// Security policies.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SecurityConfig {
     /// Maximum size of tool call arguments in bytes (default: unlimited)
     pub max_argument_size: Option<usize>,
 }
 
+/// Logging, metrics, and distributed tracing configuration.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ObservabilityConfig {
+    /// Enable audit logging of all MCP requests (default: false).
     #[serde(default)]
     pub audit: bool,
+    /// Log level filter (default: "info").
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    /// Emit structured JSON logs (default: false).
     #[serde(default)]
     pub json_logs: bool,
+    /// Prometheus metrics configuration.
     #[serde(default)]
     pub metrics: MetricsConfig,
+    /// OpenTelemetry distributed tracing configuration.
     #[serde(default)]
     pub tracing: TracingConfig,
 }
 
+/// Prometheus metrics configuration.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct MetricsConfig {
+    /// Enable Prometheus metrics at `/admin/metrics` (default: false).
     #[serde(default)]
     pub enabled: bool,
 }
 
+/// OpenTelemetry distributed tracing configuration.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TracingConfig {
+    /// Enable OTLP trace export (default: false).
     #[serde(default)]
     pub enabled: bool,
     /// OTLP endpoint (default: http://localhost:4317)
@@ -438,9 +492,13 @@ fn default_service_name() -> String {
 /// Resolved filter rules for a backend's capabilities.
 #[derive(Debug, Clone)]
 pub struct BackendFilter {
+    /// Namespace prefix (e.g. "db/") this filter applies to.
     pub namespace: String,
+    /// Filter for tool names.
     pub tool_filter: NameFilter,
+    /// Filter for resource URIs.
     pub resource_filter: NameFilter,
+    /// Filter for prompt names.
     pub prompt_filter: NameFilter,
 }
 
@@ -484,6 +542,8 @@ impl NameFilter {
 }
 
 impl BackendConfig {
+    /// Build a [`BackendFilter`] from this backend's expose/hide lists.
+    /// Returns `None` if no filtering is configured.
     pub fn build_filter(&self, separator: &str) -> Option<BackendFilter> {
         let tool_filter = if !self.expose_tools.is_empty() {
             NameFilter::AllowList(self.expose_tools.iter().cloned().collect())

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -25,6 +25,7 @@ pub struct CapabilityFilterService<S> {
 }
 
 impl<S> CapabilityFilterService<S> {
+    /// Create a new capability filter service with the given filter rules.
     pub fn new(inner: S, filters: Vec<BackendFilter>) -> Self {
         Self {
             inner,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,6 +20,7 @@ pub struct MetricsService<S> {
 }
 
 impl<S> MetricsService<S> {
+    /// Create a new metrics service wrapping `inner`.
     pub fn new(inner: S) -> Self {
         Self { inner }
     }

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -33,6 +33,7 @@ pub struct RbacConfig {
 }
 
 impl RbacConfig {
+    /// Build RBAC config from role definitions and claim-to-role mapping.
     pub fn new(roles: &[RoleConfig], mapping: &RoleMappingConfig) -> Self {
         let mut role_allow = HashMap::new();
         let mut role_deny = HashMap::new();
@@ -119,6 +120,7 @@ pub struct RbacService<S> {
 }
 
 impl<S> RbacService<S> {
+    /// Create a new RBAC enforcement service wrapping `inner`.
     pub fn new(inner: S, config: RbacConfig) -> Self {
         Self {
             inner,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -29,6 +29,7 @@ pub struct ValidationService<S> {
 }
 
 impl<S> ValidationService<S> {
+    /// Create a new validation service wrapping `inner`.
     pub fn new(inner: S, config: ValidationConfig) -> Self {
         Self {
             inner,


### PR DESCRIPTION
## Summary

Partially addresses #40.

Adds doc comments to all public structs, fields, enums, variants, and methods across the codebase. Eliminates all 79 `missing_docs` warnings:

| File | Fixed |
|------|-------|
| config.rs | 57 (module doc + all struct fields) |
| admin.rs | 8 (BackendStatus, BackendMeta) |
| cache.rs | 5 (CacheStatsSnapshot fields) |
| alias.rs | 2 (AliasMap::new, AliasService::new) |
| rbac.rs | 2 (RbacConfig::new, RbacService::new) |
| validation.rs | 1 (ValidationService::new) |
| metrics.rs | 1 (MetricsService::new) |
| filter.rs | 1 (CapabilityFilterService::new) |
| coalesce.rs | 1 (CoalesceService::new) |

`RUSTDOCFLAGS="-W missing_docs" cargo doc` now produces zero warnings.

## Test plan

- [x] `cargo doc --no-deps --all-features` builds clean
- [x] `cargo test --doc --all-features` passes
- [x] `cargo clippy` clean
- [x] `cargo test --lib` passes (105 tests)