### PR TITLE
Rename to mcp-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "mcp-gateway"
+name = "mcp-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
-name = "mcp-gateway"
+name = "mcp-proxy"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.90"
-description = "Standalone MCP gateway -- config-driven proxy with auth, rate limiting, and observability"
+description = "Standalone MCP proxy -- config-driven reverse proxy with auth, rate limiting, and observability"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/joshrotenberg/mcp-proxy"
+homepage = "https://github.com/joshrotenberg/mcp-proxy"
 
 [lib]
-name = "mcp_gateway"
+name = "mcp_proxy"
 
 [[bin]]
-name = "mcp-gateway"
+name = "mcp-proxy"
 path = "src/main.rs"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,21 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 
-RUN cargo build --release --bin mcp-gateway
+RUN cargo build --release --bin mcp-proxy
 
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/mcp-gateway /usr/local/bin/mcp-gateway
+COPY --from=builder /build/target/release/mcp-proxy /usr/local/bin/mcp-proxy
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+HEALTHCHECK --interval=30s --timeout=5s --start_period=10s \
     CMD curl -f http://localhost:8080/admin/backends || exit 1
 
-ENTRYPOINT ["mcp-gateway"]
-CMD ["--config", "/etc/mcp-gateway/gateway.toml"]
+ENTRYPOINT ["mcp-proxy"]
+CMD ["--config", "/etc/mcp-proxy/gateway.toml"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mcp-gateway
+# mcp-proxy
 
-A config-driven [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) gateway built in Rust. Aggregates multiple MCP backends behind a single endpoint with per-backend middleware, authentication, and observability.
+A config-driven [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) reverse proxy built in Rust. Aggregates multiple MCP backends behind a single endpoint with per-backend middleware, authentication, and observability.
 
 Built on [tower-mcp](https://github.com/joshrotenberg/tower-mcp) and the [tower](https://github.com/tower-rs/tower) middleware ecosystem.
 
@@ -12,7 +12,7 @@ Built on [tower-mcp](https://github.com/joshrotenberg/tower-mcp) and the [tower]
 - **Tool aliasing** -- rename tools exposed by backends
 - **Argument injection** -- merge default or per-tool arguments into tool calls
 - **Hot reload** -- watch config file and add new backends without restart
-- **Library mode** -- embed the gateway in your own Rust application
+- **Library mode** -- embed the proxy in your own Rust application
 
 ### Resilience
 - **Timeout** -- per-backend request timeouts
@@ -39,19 +39,19 @@ Built on [tower-mcp](https://github.com/joshrotenberg/tower-mcp) and the [tower]
 - **OpenTelemetry tracing** -- distributed trace export via OTLP
 - **Audit logging** -- structured logging of all MCP requests
 - **Admin API** -- health checks, backend status, cache stats
-- **Admin MCP tools** -- gateway introspection tools under `gateway/` namespace
+- **Admin MCP tools** -- introspection tools under `gateway/` namespace
 
 ## Quick Start
 
 ```bash
-cargo install mcp-gateway
+cargo install mcp-proxy
 ```
 
 Create a `gateway.toml`:
 
 ```toml
 [gateway]
-name = "my-gateway"
+name = "my-proxy"
 separator = "/"
 
 [gateway.listen]
@@ -68,7 +68,7 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
 Run:
 
 ```bash
-mcp-gateway --config gateway.toml
+mcp-proxy --config gateway.toml
 ```
 
 All tools from the filesystem server are now available under the `files/` namespace at `http://127.0.0.1:8080/mcp`.
@@ -173,7 +173,7 @@ tokens = ["my-secret-token"]
 [auth]
 type = "jwt"
 issuer = "https://auth.example.com"
-audience = "mcp-gateway"
+audience = "mcp-proxy"
 jwks_uri = "https://auth.example.com/.well-known/jwks.json"
 
 [[auth.roles]]
@@ -208,11 +208,11 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcp-gateway = "0.1"
+mcp-proxy = "0.1"
 ```
 
 ```rust
-use mcp_gateway::{Gateway, GatewayConfig};
+use mcp_proxy::{Gateway, GatewayConfig};
 
 let config = GatewayConfig::load("gateway.toml".as_ref())?;
 let gateway = Gateway::from_config(config).await?;
@@ -228,7 +228,7 @@ gateway.serve().await?;
 
 HTTP endpoints:
 
-- `GET /admin/backends` -- list backends with health status and gateway info
+- `GET /admin/backends` -- list backends with health status and proxy info
 - `GET /admin/health` -- health check summary (healthy/degraded)
 - `GET /admin/metrics` -- Prometheus metrics
 - `GET /admin/cache/stats` -- per-backend cache hit/miss rates

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,4 @@
-# mcp-gateway configuration
+# mcp-proxy configuration
 
 [gateway]
 name = "my-gateway"
@@ -16,10 +16,10 @@ host = "127.0.0.1"
 port = 8080
 
 # Optional: custom instructions sent to clients on initialize
-# instructions = "This gateway aggregates multiple MCP backends."
+# instructions = "This proxy aggregates multiple MCP backends."
 
 # --- Backends ---
-# Each backend is an MCP server the gateway proxies to.
+# Each backend is an MCP server the proxy routes to.
 # The name becomes the namespace prefix for all tools/resources/prompts.
 
 [[backends]]
@@ -155,7 +155,7 @@ period_seconds = 1
 # [auth]
 # type = "jwt"
 # issuer = "https://auth.example.com"
-# audience = "mcp-gateway"
+# audience = "mcp-proxy"
 # jwks_uri = "https://auth.example.com/.well-known/jwks.json"
 #
 # # Define roles with tool access control
@@ -198,4 +198,4 @@ enabled = true
 # [observability.tracing]
 # enabled = true
 # endpoint = "http://localhost:4317"
-# service_name = "mcp-gateway"
+# service_name = "mcp-proxy"

--- a/docs/architectures.md
+++ b/docs/architectures.md
@@ -3,7 +3,7 @@
 Research compiled March 2026. This document catalogs theoretical and real-world
 architecture patterns for an MCP gateway, informed by emerging industry practice,
 traditional API gateway patterns (Kong, Envoy, Traefik), and the specific
-capabilities of `mcp-gateway`.
+capabilities of `mcp-proxy`.
 
 ---
 
@@ -17,7 +17,7 @@ unmanageable, and IT has no visibility into what tools are being used or by whom
 **Architecture:**
 ```
 Developer (Claude Code / Cursor / Windsurf)
-  --> mcp-gateway (central, IT-managed)
+  --> mcp-proxy (central, IT-managed)
         --> github backend (stdio)
         --> jira backend (http)
         --> confluence backend (http)
@@ -39,7 +39,7 @@ circuit breaker, capability filtering, audit logging, Prometheus metrics.
 
 **Industry precedent:** Kong, Traefik Hub, and Envoy AI Gateway all offer
 enterprise MCP gateway products with similar consolidation patterns. Microsoft's
-mcp-gateway project provides Kubernetes-based session-aware routing for this
+mcp-proxy project provides Kubernetes-based session-aware routing for this
 use case.
 
 ---
@@ -55,7 +55,7 @@ the network.
 **Architecture:**
 ```
 AI Assistants (restricted network)
-  --> mcp-gateway (DMZ, hardened)
+  --> mcp-proxy (DMZ, hardened)
         --> market-data backend (http, read-only)
         --> portfolio-analytics backend (http, read-only)
         --> trade-execution backend (http, write, restricted)
@@ -92,7 +92,7 @@ with isolated permissions.
 **Architecture:**
 ```
 Agent
-  --> mcp-gateway
+  --> mcp-proxy
         --> fs backend (stdio, runs as restricted user)
         --> search backend (http, Kubernetes pod)
         --> db backend (http, Kubernetes pod)
@@ -111,7 +111,7 @@ circuit breaker, capability filtering, hot reload.
 
 **Industry precedent:** The MicroMCP project on GitHub explicitly implements
 this pattern. Envoy AI Gateway auto-prefixes tool names with backend names
-(e.g., `github__issue_read`), identical to mcp-gateway's namespace separator.
+(e.g., `github__issue_read`), identical to mcp-proxy's namespace separator.
 
 ---
 
@@ -125,7 +125,7 @@ want both to see the same tools without duplicating config.
 **Architecture:**
 ```
 Claude Code  --\
-                --> mcp-gateway (localhost:8080)
+                --> mcp-proxy (localhost:8080)
 Cursor       --/      --> filesystem backend (stdio)
                       --> github backend (stdio)
                       --> sqlite backend (stdio)
@@ -161,7 +161,7 @@ identity.
 **Architecture:**
 ```
 Planning Agent (role: orchestrator)  --\
-Coding Agent (role: coder)           --+--> mcp-gateway
+Coding Agent (role: coder)           --+--> mcp-proxy
 Research Agent (role: researcher)    --/      --> github backend
 Data Agent (role: analyst)           --/      --> web-search backend
                                               --> filesystem backend
@@ -199,7 +199,7 @@ and rate limits. The gateway is the product boundary.
 
 **Architecture:**
 ```
-Customer A Agent --> mcp-gateway (multi-tenant)
+Customer A Agent --> mcp-proxy (multi-tenant)
 Customer B Agent -->      --> customer-a/crm backend
 Customer C Agent -->      --> customer-a/analytics backend
                           --> customer-b/crm backend
@@ -239,7 +239,7 @@ reliability are critical.
 **Architecture:**
 ```
 Central AI System
-  --> mcp-gateway (edge aggregation point)
+  --> mcp-proxy (edge aggregation point)
         --> sensor-array-1 backend (http, 10.0.1.x)
         --> sensor-array-2 backend (http, 10.0.2.x)
         --> plc-controller backend (http, 10.0.3.x)
@@ -277,7 +277,7 @@ to prevent unintended deployments.
 **Architecture:**
 ```
 CI Agent (role: ci-bot)
-  --> mcp-gateway
+  --> mcp-proxy
         --> circleci backend (http)
         --> github backend (stdio)
         --> sonarqube backend (http)
@@ -314,7 +314,7 @@ configuration changes before production.
 **Architecture:**
 ```
 Test harness / MCP Inspector
-  --> mcp-gateway (test config)
+  --> mcp-proxy (test config)
         --> stable-api backend (http, production mirror)
         --> experimental-api backend (http, staging)
         --> mock-db backend (stdio, returns canned responses)
@@ -350,7 +350,7 @@ audit trail. No direct MCP server access is permitted.
 **Architecture:**
 ```
 Any AI client (must present JWT)
-  --> mcp-gateway (zero-trust perimeter)
+  --> mcp-proxy (zero-trust perimeter)
         [Auth layer: verify JWT, extract claims]
         [Validation layer: check argument sizes, scan for injection]
         [Filter layer: RBAC-based tool visibility]
@@ -390,7 +390,7 @@ and reduce token consumption.
 **Architecture:**
 ```
 Multiple AI agents
-  --> mcp-gateway (cost optimization layer)
+  --> mcp-proxy (cost optimization layer)
         [Cache layer: aggressive TTLs on read-heavy tools]
         [Coalesce layer: deduplicate concurrent identical requests]
         [Filter layer: hide tools that generate excessive tokens]
@@ -430,7 +430,7 @@ lightweight MCP server adapters that wrap each legacy API.
 **Architecture:**
 ```
 AI Agents
-  --> mcp-gateway
+  --> mcp-proxy
         --> crm-adapter backend (stdio, wraps REST CRM API)
         --> erp-adapter backend (stdio, wraps gRPC ERP)
         --> legacy-db backend (stdio, wraps ODBC connection)
@@ -467,11 +467,11 @@ team autonomy.
 ```
 Organization-wide AI agents
   --> org-gateway (top-level federation)
-        --> engineering-gateway backend (http, runs its own mcp-gateway)
+        --> engineering-gateway backend (http, runs its own mcp-proxy)
               --> github, ci, monitoring backends
-        --> data-team-gateway backend (http, runs its own mcp-gateway)
+        --> data-team-gateway backend (http, runs its own mcp-proxy)
               --> warehouse, analytics, ml-ops backends
-        --> security-gateway backend (http, runs its own mcp-gateway)
+        --> security-gateway backend (http, runs its own mcp-proxy)
               --> siem, scanner, compliance backends
 ```
 
@@ -502,7 +502,7 @@ human-in-the-loop oversight.
 **Architecture:**
 ```
 Autonomous AI Agents
-  --> mcp-gateway (guardrail layer)
+  --> mcp-proxy (guardrail layer)
         [Admin API: enable/disable tools in real-time]
         [Rate limiting: detect and throttle runaway agents]
         [Circuit breaker: automatic protection]
@@ -538,7 +538,7 @@ its own interface without running a separate gateway process.
 **Architecture:**
 ```
 Custom Rust Application
-  --> embedded mcp-gateway (library)
+  --> embedded mcp-proxy (library)
         --> app-specific backend (in-process)
         --> external-api backend (http)
         --> local-tools backend (stdio)
@@ -556,7 +556,7 @@ Custom Rust Application
 
 **Industry precedent:** This follows the pattern of embedding Envoy as a
 library (via envoy-mobile) or embedding Kong's core as a library. The
-mcp-gateway already supports this via `mcp-gateway = "0.1"` as a crate
+mcp-proxy already supports this via `mcp-proxy = "0.1"` as a crate
 dependency with `into_router()` for axum integration.
 
 ---
@@ -598,7 +598,7 @@ dependency with `into_router()` for axum integration.
 5. **Federation and registry** patterns are maturing, with ContextForge
    and MintMCP providing tool discovery, versioning, and marketplace features.
 
-6. **Rust-based gateways** (Sentinel, mcp-gateway) are emerging for
+6. **Rust-based gateways** (Sentinel, mcp-proxy) are emerging for
    performance-critical deployments, following the trajectory of Envoy (C++)
    and Linkerd (Rust) in the service mesh space.
 
@@ -610,17 +610,17 @@ dependency with `into_router()` for axum integration.
 - [Micro-MCP: Namespaces and Policy (GitHub/DEV)](https://github.com/mabualzait/MicroMCP)
 - [Envoy AI Gateway MCP Implementation](https://aigateway.envoyproxy.io/blog/mcp-implementation/)
 - [Envoy AI Gateway MCP Performance](https://aigateway.envoyproxy.io/blog/mcp-in-envoy-ai-gateway/)
-- [Kong Enterprise MCP Gateway](https://konghq.com/blog/product-releases/enterprise-mcp-gateway)
-- [Traefik MCP Gateway](https://traefik.io/solutions/mcp-gateway)
+- [Kong Enterprise MCP Gateway](https://konghq.com/blog/product-releases/enterprise-mcp-proxy)
+- [Traefik MCP Gateway](https://traefik.io/solutions/mcp-proxy)
 - [IBM ContextForge](https://ibm.github.io/mcp-context-forge/)
 - [MCP Best Practices (modelcontextprotocol.info)](https://modelcontextprotocol.info/docs/best-practices/)
 - [Enterprise MCP Part Two (FactSet)](https://medium.com/factset/enterprise-mcp-model-context-protocol-part-two-f5cdd7c0444b)
 - [MCP for IoT (Glama)](https://glama.ai/blog/2025-08-19-bringing-ai-to-the-edge-mcp-for-iot)
 - [MCP and IoT (IEEE)](https://ieeexplore.ieee.org/iel8/8548628/11333934/11235950.pdf)
-- [MCP Gateway (Composio)](https://composio.dev/blog/mcp-gateways-guide)
-- [MCP Gateway Best Practices (Traefik Hub)](https://doc.traefik.io/traefik-hub/mcp-gateway/guides/mcp-gateway-best-practices)
+- [MCP Gateway (Composio)](https://composio.dev/blog/mcp-proxys-guide)
+- [MCP Gateway Best Practices (Traefik Hub)](https://doc.traefik.io/traefik-hub/mcp-proxy/guides/mcp-proxy-best-practices)
 - [MCP API Gateway Explained (Gravitee)](https://www.gravitee.io/blog/mcp-api-gateway-explained-protocols-caching-and-remote-server-integration)
-- [Advanced Auth for MCP Gateway (Red Hat)](https://developers.redhat.com/articles/2025/12/12/advanced-authentication-authorization-mcp-gateway)
+- [Advanced Auth for MCP Gateway (Red Hat)](https://developers.redhat.com/articles/2025/12/12/advanced-authentication-authorization-mcp-proxy)
 - [MCP Registry and Gateway Comparison](https://www.paperclipped.de/en/blog/mcp-registry-gateway-enterprise-ai-agents/)
 - [Sentinel MCP Gateway (Rust)](https://wallyblanchard.com/sentinel.html)
 - [Resilient AI Agents: Timeout and Retry (Octopus)](https://octopus.com/blog/mcp-timeout-retry)

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,8 +1,8 @@
-# mcp-gateway Design Document
+# mcp-proxy Design Document
 
 ## Overview
 
-mcp-gateway is a standalone, config-driven MCP proxy server built on tower-mcp.
+mcp-proxy is a standalone, config-driven MCP proxy server built on tower-mcp.
 It aggregates multiple MCP backend servers behind a single HTTP endpoint,
 adding auth, resilience, observability, and routing capabilities.
 
@@ -61,7 +61,7 @@ tokens = ["token-1", "token-2"]
 [auth]
 type = "jwt"
 issuer = "https://auth.example.com"
-audience = "mcp-gateway"
+audience = "mcp-proxy"
 jwks_uri = "https://auth.example.com/.well-known/jwks.json"
 ```
 
@@ -314,14 +314,14 @@ Expose Prometheus-compatible metrics.
 enabled = true
 endpoint = "/metrics"     # Prometheus scrape endpoint
 # Metrics emitted:
-# - mcp_gateway_requests_total{backend, method, status}
-# - mcp_gateway_request_duration_seconds{backend, method}
-# - mcp_gateway_backend_health{backend}
-# - mcp_gateway_active_sessions
+# - mcp_proxy_requests_total{backend, method, status}
+# - mcp_proxy_request_duration_seconds{backend, method}
+# - mcp_proxy_backend_health{backend}
+# - mcp_proxy_active_sessions
 ```
 
-**Status:** Done. `MetricsService` middleware records `mcp_gateway_requests_total{method, status}`
-(counter) and `mcp_gateway_request_duration_seconds{method}` (histogram).
+**Status:** Done. `MetricsService` middleware records `mcp_proxy_requests_total{method, status}`
+(counter) and `mcp_proxy_request_duration_seconds{method}` (histogram).
 Uses `metrics` + `metrics-exporter-prometheus`. Prometheus scrape endpoint at `/admin/metrics`.
 Enabled via `[observability.metrics] enabled = true`.
 
@@ -334,7 +334,7 @@ OpenTelemetry trace propagation.
 enabled = true
 exporter = "otlp"         # or "jaeger", "zipkin"
 endpoint = "http://localhost:4317"
-service_name = "mcp-gateway"
+service_name = "mcp-proxy"
 ```
 
 **Status:** Done. When `[observability.tracing] enabled = true`, bridges all `tracing` spans
@@ -570,13 +570,13 @@ Power-user features.
 
 ### Phase 6: Library Mode
 
-Make mcp-gateway embeddable as a library so other Rust applications can
+Make mcp-proxy embeddable as a library so other Rust applications can
 programmatically build and run a gateway without the CLI/config file.
 
 21. **Extract `lib.rs`** -- move all gateway logic out of `main.rs` into a library crate
 22. **`GatewayBuilder` API** -- programmatic builder that mirrors the config-driven flow
     ```rust
-    let gateway = mcp_gateway::GatewayBuilder::new("my-gw", "1.0.0")
+    let gateway = mcp_proxy::GatewayBuilder::new("my-gw", "1.0.0")
         .backend_stdio("files", "npx", &["-y", "@mcp/server-filesystem", "/tmp"])
         .backend_http("remote", "http://mcp:8080")
         .auth_bearer(&["token-1"])
@@ -592,7 +592,7 @@ programmatically build and run a gateway without the CLI/config file.
     gateway.serve("127.0.0.1:8080").await?;
     ```
 23. **Config-from-struct** -- `GatewayConfig` usable directly without TOML parsing
-24. **Dual crate structure** -- `mcp-gateway` (lib) + `mcp-gateway-cli` (bin), or
+24. **Dual crate structure** -- `mcp-proxy` (lib) + `mcp-proxy-cli` (bin), or
     single crate with `[[bin]]` and `[lib]`
 
 **Status:** Done. Single crate with `[lib]` + `[[bin]]` targets.
@@ -660,7 +660,7 @@ port = 8080
 [auth]
 type = "jwt"
 issuer = "https://auth.example.com"
-audience = "mcp-gateway"
+audience = "mcp-proxy"
 jwks_uri = "https://auth.example.com/.well-known/jwks.json"
 
 [[auth.roles]]
@@ -700,7 +700,7 @@ endpoint = "/metrics"
 enabled = true
 exporter = "otlp"
 endpoint = "http://localhost:4317"
-service_name = "mcp-gateway"
+service_name = "mcp-proxy"
 
 [observability.health]
 endpoint = "/health"
@@ -749,7 +749,7 @@ invalidate_on_notify = true
 
 ## tower-mcp Gaps Identified
 
-Tracked as tower-mcp issues (without mentioning mcp-gateway):
+Tracked as tower-mcp issues (without mentioning mcp-proxy):
 
 | Gap | Issue | Status |
 |-----|-------|--------|

--- a/examples/developer-local.toml
+++ b/examples/developer-local.toml
@@ -3,7 +3,7 @@
 # Lightweight config for individual developers. Consolidates personal
 # MCP servers behind a single endpoint. No auth needed for local use.
 #
-# Usage: mcp-gateway --config examples/developer-local.toml
+# Usage: mcp-proxy --config examples/developer-local.toml
 #
 # See: docs/architectures.md #3
 

--- a/examples/enterprise-hub.toml
+++ b/examples/enterprise-hub.toml
@@ -1,6 +1,6 @@
 # Enterprise Tool Consolidation Hub
 #
-# Central IT-managed gateway for all developer MCP tooling.
+# Central IT-managed proxy for all developer MCP tooling.
 # Replaces per-developer mcp.json configs with a single managed endpoint.
 # JWT auth via corporate IdP, RBAC per team, full audit trail.
 #
@@ -20,7 +20,7 @@ port = 8080
 [auth]
 type = "jwt"
 issuer = "https://corp.okta.com"
-audience = "mcp-gateway"
+audience = "mcp-proxy"
 jwks_uri = "https://corp.okta.com/oauth2/default/v1/keys"
 
 # Role definitions
@@ -144,4 +144,4 @@ enabled = true
 [observability.tracing]
 enabled = true
 endpoint = "http://jaeger.internal:4317"
-service_name = "mcp-gateway"
+service_name = "mcp-proxy"

--- a/src/admin_tools.rs
+++ b/src/admin_tools.rs
@@ -200,7 +200,7 @@ fn build_admin_router(state: AdminToolState) -> McpRouter {
         .build();
 
     McpRouter::new()
-        .server_info("mcp-gateway-admin", "0.1.0")
+        .server_info("mcp-proxy-admin", "0.1.0")
         .tool(list_backends)
         .tool(health_check)
         .tool(session_count)

--- a/src/config.rs
+++ b/src/config.rs
@@ -382,7 +382,7 @@ pub struct TracingConfig {
     /// OTLP endpoint (default: http://localhost:4317)
     #[serde(default = "default_otlp_endpoint")]
     pub endpoint: String,
-    /// Service name for traces (default: "mcp-gateway")
+    /// Service name for traces (default: "mcp-proxy")
     #[serde(default = "default_service_name")]
     pub service_name: String,
 }
@@ -486,7 +486,7 @@ fn default_otlp_endpoint() -> String {
 }
 
 fn default_service_name() -> String {
-    "mcp-gateway".to_string()
+    "mcp-proxy".to_string()
 }
 
 /// Resolved filter rules for a backend's capabilities.
@@ -520,7 +520,7 @@ impl NameFilter {
     ///
     /// ```
     /// use std::collections::HashSet;
-    /// use mcp_gateway::config::NameFilter;
+    /// use mcp_proxy::config::NameFilter;
     ///
     /// let filter = NameFilter::DenyList(["delete".to_string()].into());
     /// assert!(filter.allows("read"));
@@ -602,7 +602,7 @@ impl GatewayConfig {
     /// # Examples
     ///
     /// ```
-    /// use mcp_gateway::GatewayConfig;
+    /// use mcp_proxy::GatewayConfig;
     ///
     /// let config = GatewayConfig::parse(r#"
     ///     [gateway]
@@ -935,7 +935,7 @@ mod tests {
         [auth]
         type = "jwt"
         issuer = "https://auth.example.com"
-        audience = "mcp-gateway"
+        audience = "mcp-proxy"
         jwks_uri = "https://auth.example.com/.well-known/jwks.json"
 
         [[auth.roles]]
@@ -960,7 +960,7 @@ mod tests {
                 role_mapping,
             }) => {
                 assert_eq!(issuer, "https://auth.example.com");
-                assert_eq!(audience, "mcp-gateway");
+                assert_eq!(audience, "mcp-proxy");
                 assert_eq!(jwks_uri, "https://auth.example.com/.well-known/jwks.json");
                 assert_eq!(roles.len(), 2);
                 assert_eq!(roles[0].name, "reader");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-//! MCP Gateway -- config-driven proxy with auth, rate limiting, and observability.
+//! MCP Proxy -- config-driven reverse proxy with auth, rate limiting, and observability.
 //!
-//! This crate can be used as a library to embed an MCP gateway in your application,
-//! or run standalone via the `mcp-gateway` CLI.
+//! This crate can be used as a library to embed an MCP proxy in your application,
+//! or run standalone via the `mcp-proxy` CLI.
 //!
 //! # Library Usage
 //!
-//! Build a gateway from a [`GatewayConfig`] and embed it in an existing axum app:
+//! Build a proxy from a [`GatewayConfig`] and embed it in an existing axum app:
 //!
 //! ```rust,no_run
-//! use mcp_gateway::{Gateway, GatewayConfig};
+//! use mcp_proxy::{Gateway, GatewayConfig};
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! let config = GatewayConfig::load("gateway.toml".as_ref())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 
-use mcp_gateway::Gateway;
-use mcp_gateway::config::GatewayConfig;
+use mcp_proxy::Gateway;
+use mcp_proxy::config::GatewayConfig;
 
 #[derive(Parser)]
-#[command(name = "mcp-gateway", about = "Standalone MCP gateway")]
+#[command(name = "mcp-proxy", about = "Standalone MCP proxy")]
 struct Cli {
     /// Path to config file
     #[arg(short, long, default_value = "gateway.toml")]
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         name = %config.gateway.name,
         version = %config.gateway.version,
         backends = config.backends.len(),
-        "Starting MCP gateway"
+        "Starting MCP proxy"
     );
 
     let hot_reload = config.gateway.hot_reload;
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
 
 fn init_logging(config: &GatewayConfig) {
     let env_filter = format!(
-        "tower_mcp={level},mcp_gateway={level}",
+        "tower_mcp={level},mcp_proxy={level}",
         level = config.observability.log_level
     );
 
@@ -69,7 +69,7 @@ fn init_logging(config: &GatewayConfig) {
             )
             .build();
 
-        let tracer = provider.tracer("mcp-gateway");
+        let tracer = provider.tracer("mcp-proxy");
         let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
         let fmt_layer = if config.observability.json_logs {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,10 +62,10 @@ where
                 Err(_) => "error",
             };
 
-            counter!("mcp_gateway_requests_total", "method" => method.clone(), "status" => status)
+            counter!("mcp_proxy_requests_total", "method" => method.clone(), "status" => status)
                 .increment(1);
             histogram!(
-                "mcp_gateway_request_duration_seconds",
+                "mcp_proxy_request_duration_seconds",
                 "method" => method,
             )
             .record(duration);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,15 +15,15 @@ use tower_mcp::proxy::McpProxy;
 use tower_mcp::router::{Extensions, RouterRequest, RouterResponse};
 use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
 
-use mcp_gateway::alias::{AliasMap, AliasService};
-use mcp_gateway::cache::CacheService;
-use mcp_gateway::coalesce::CoalesceService;
-use mcp_gateway::config::BackendCacheConfig;
-use mcp_gateway::config::{BackendFilter, InjectArgsConfig, NameFilter};
-use mcp_gateway::filter::CapabilityFilterService;
-use mcp_gateway::inject::{InjectArgsService, InjectionRules};
-use mcp_gateway::mirror::MirrorService;
-use mcp_gateway::validation::{ValidationConfig, ValidationService};
+use mcp_proxy::alias::{AliasMap, AliasService};
+use mcp_proxy::cache::CacheService;
+use mcp_proxy::coalesce::CoalesceService;
+use mcp_proxy::config::BackendCacheConfig;
+use mcp_proxy::config::{BackendFilter, InjectArgsConfig, NameFilter};
+use mcp_proxy::filter::CapabilityFilterService;
+use mcp_proxy::inject::{InjectArgsService, InjectionRules};
+use mcp_proxy::mirror::MirrorService;
+use mcp_proxy::validation::{ValidationConfig, ValidationService};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct AddInput {


### PR DESCRIPTION
## Summary
- Rename crate/binary from `mcp-gateway` to `mcp-proxy`
- `mcp-gateway` is taken on crates.io and "proxy" better describes the project
- All source, config, docs, Dockerfile, and example references updated
- Added `repository` and `homepage` to Cargo.toml

## Changes
- 15 files, all `mcp-gateway` / `mcp_gateway` references replaced
- Metrics prefix: `mcp_proxy_requests_total`, `mcp_proxy_request_duration_seconds`
- Binary: `mcp-proxy`
- Lib: `mcp_proxy`
- Default tracing service name: `mcp-proxy`

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] 114 lib tests pass
- [x] 18 integration tests pass
- [x] `cargo doc` builds

Closes #50