### PR TITLE
fix: exclude docker-compose proxy.toml from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 CLAUDE.md
 proxy*.toml
 !config.example.toml
+!examples/docker-compose/proxy.toml


### PR DESCRIPTION
## Summary

- Add `!examples/docker-compose/proxy.toml` to `.gitignore` to unblock release-plz
- The `proxy*.toml` pattern was ignoring a tracked file, causing release-plz to fail with "uncommitted changes" error

## Test plan

- [x] release-plz CI should pass after this