### PR TITLE
fix: update CI workflows for master -> main rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-plz:


### PR DESCRIPTION
## Summary

- Update ci.yml and release-plz.yml to trigger on `main` instead of `master`
- Required after branch rename in #66

## Test plan

- [x] CI should trigger on this PR (proves the `pull_request` branch target works)
- [x] release-plz should trigger on merge to `main`