### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-03-08
+
+### Documentation
+
+- Add installation methods to README
+- Add installation methods and optimize dist profile ([#71](https://github.com/joshrotenberg/mcp-proxy/pull/71))
+
+### Miscellaneous Tasks
+
+- Release v0.1.0
+
+
+
 ## [0.1.0] - 2026-03-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.90"
 description = "Standalone MCP proxy -- config-driven reverse proxy with auth, rate limiting, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2026-03-08

### Documentation

- Add installation methods to README
- Add installation methods and optimize dist profile ([#71](https://github.com/joshrotenberg/mcp-proxy/pull/71))

### Miscellaneous Tasks

- Release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).