### PR TITLE
docs: add installation methods and optimize dist profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,14 @@ name = "mcp_proxy"
 name = "mcp-proxy"
 path = "src/main.rs"
 
+[features]
+default = ["otel", "metrics", "oauth"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
+metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
+oauth = ["tower-mcp/oauth", "tower-mcp/jwks"]
+
 [dependencies]
-tower-mcp = { version = "0.8.3", features = ["http", "http-client", "proxy", "oauth", "jwks"] }
+tower-mcp = { version = "0.8.3", features = ["http", "http-client", "proxy"] }
 tower-mcp-types = "0.8.3"
 axum = "0.8"
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
@@ -29,12 +35,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
-metrics = "0.24.3"
-metrics-exporter-prometheus = "0.18.1"
-opentelemetry = "0.29"
-opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.29"
-tracing-opentelemetry = "0.30"
+metrics = { version = "0.24.3", optional = true }
+metrics-exporter-prometheus = { version = "0.18.1", optional = true }
+opentelemetry = { version = "0.29", optional = true }
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.29", optional = true }
+tracing-opentelemetry = { version = "0.30", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 schemars = "1"
 moka = { version = "0.12.14", features = ["future"] }

--- a/README.md
+++ b/README.md
@@ -287,6 +287,26 @@ Client
 
 Global middleware wraps the entire proxy. Per-backend middleware is applied individually to each backend connection. All middleware is built with tower `Service` layers.
 
+## Feature Flags
+
+Pre-built binaries and `cargo install` include all features by default. If you're building from source and don't need everything, you can disable optional features for a smaller binary:
+
+| Feature | Default | What it includes |
+|---------|---------|-----------------|
+| `otel` | yes | OpenTelemetry distributed tracing (OTLP export) |
+| `metrics` | yes | Prometheus metrics and `/admin/metrics` endpoint |
+| `oauth` | yes | JWT/JWKS auth, RBAC, and token passthrough |
+
+```bash
+# Minimal build (bearer auth only, no metrics/tracing/JWT)
+cargo install mcp-proxy --no-default-features
+
+# Just metrics, no otel or JWT
+cargo install mcp-proxy --no-default-features --features metrics
+```
+
+Config parsing always works regardless of features -- if you reference a disabled feature in your config (e.g., `type = "jwt"` without the `oauth` feature), you'll get a clear error at startup.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -190,6 +190,7 @@ struct HealthResponse {
     unhealthy_backends: Vec<String>,
 }
 
+#[cfg(feature = "metrics")]
 async fn handle_metrics(
     Extension(handle): Extension<Option<metrics_exporter_prometheus::PrometheusHandle>>,
 ) -> impl IntoResponse {
@@ -197,6 +198,11 @@ async fn handle_metrics(
         Some(h) => h.render(),
         None => String::new(),
     }
+}
+
+#[cfg(not(feature = "metrics"))]
+async fn handle_metrics() -> impl IntoResponse {
+    String::new()
 }
 
 async fn handle_cache_stats(
@@ -235,23 +241,36 @@ fn test_admin_state(
     }
 }
 
+/// Metrics handle type -- wraps the Prometheus handle when the feature is enabled.
+#[cfg(feature = "metrics")]
+pub type MetricsHandle = Option<metrics_exporter_prometheus::PrometheusHandle>;
+/// Metrics handle type -- no-op when the metrics feature is disabled.
+#[cfg(not(feature = "metrics"))]
+pub type MetricsHandle = Option<()>;
+
 /// Build the admin API router.
 pub fn admin_router(
     state: AdminState,
-    metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
+    metrics_handle: MetricsHandle,
     session_handle: SessionHandle,
     cache_handle: Option<crate::cache::CacheHandle>,
 ) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/backends", get(handle_backends))
         .route("/health", get(handle_health))
         .route("/cache/stats", get(handle_cache_stats))
         .route("/cache/clear", axum::routing::post(handle_cache_clear))
         .route("/metrics", get(handle_metrics))
         .layer(Extension(state))
-        .layer(Extension(metrics_handle))
         .layer(Extension(session_handle))
-        .layer(Extension(cache_handle))
+        .layer(Extension(cache_handle));
+
+    #[cfg(feature = "metrics")]
+    let router = router.layer(Extension(metrics_handle));
+    #[cfg(not(feature = "metrics"))]
+    let _ = metrics_handle;
+
+    router
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,15 @@ pub mod coalesce;
 pub mod config;
 pub mod filter;
 pub mod inject;
+#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod mirror;
 pub mod outlier;
+#[cfg(feature = "oauth")]
 pub mod rbac;
 pub mod reload;
 pub mod retry;
+#[cfg(feature = "oauth")]
 pub mod token;
 pub mod validation;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ fn init_logging(config: &ProxyConfig) {
         level = config.observability.log_level
     );
 
+    #[cfg(feature = "otel")]
     if config.observability.tracing.enabled {
         use opentelemetry::trace::TracerProvider;
         use opentelemetry_otlp::WithExportConfig;
@@ -94,15 +95,16 @@ fn init_logging(config: &ProxyConfig) {
             service_name = %config.observability.tracing.service_name,
             "OpenTelemetry tracing enabled"
         );
-    } else {
-        let subscriber = tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .with_writer(std::io::stderr);
+        return;
+    }
 
-        if config.observability.json_logs {
-            subscriber.json().init();
-        } else {
-            subscriber.init();
-        }
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr);
+
+    if config.observability.json_logs {
+        subscriber.json().init();
+    } else {
+        subscriber.init();
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,7 +20,7 @@ use crate::cache;
 use crate::coalesce;
 use crate::config::{AuthConfig, ProxyConfig, TransportType};
 use crate::filter::CapabilityFilterService;
-use crate::metrics;
+#[cfg(feature = "oauth")]
 use crate::rbac::{RbacConfig, RbacService};
 use crate::validation::{ValidationConfig, ValidationService};
 
@@ -44,6 +44,7 @@ impl Proxy {
         let proxy_for_caller = mcp_proxy.clone();
 
         // Install Prometheus metrics recorder (must happen before middleware)
+        #[cfg(feature = "metrics")]
         let metrics_handle = if config.observability.metrics.enabled {
             tracing::info!("Prometheus metrics enabled at /admin/metrics");
             let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
@@ -54,6 +55,8 @@ impl Proxy {
         } else {
             None
         };
+        #[cfg(not(feature = "metrics"))]
+        let metrics_handle = None;
 
         let (service, cache_handle) = build_middleware_stack(&config, mcp_proxy)?;
 
@@ -550,48 +553,52 @@ fn build_middleware_stack(
     }
 
     // RBAC (JWT auth only)
-    let rbac_config = match &config.auth {
-        Some(AuthConfig::Jwt {
-            roles,
-            role_mapping: Some(mapping),
-            ..
-        }) if !roles.is_empty() => {
-            tracing::info!(
-                roles = roles.len(),
-                claim = %mapping.claim,
-                "Enabling RBAC"
-            );
-            Some(RbacConfig::new(roles, mapping))
+    #[cfg(feature = "oauth")]
+    {
+        let rbac_config = match &config.auth {
+            Some(AuthConfig::Jwt {
+                roles,
+                role_mapping: Some(mapping),
+                ..
+            }) if !roles.is_empty() => {
+                tracing::info!(
+                    roles = roles.len(),
+                    claim = %mapping.claim,
+                    "Enabling RBAC"
+                );
+                Some(RbacConfig::new(roles, mapping))
+            }
+            _ => None,
+        };
+
+        if let Some(rbac) = rbac_config {
+            service = BoxCloneService::new(RbacService::new(service, rbac));
         }
-        _ => None,
-    };
 
-    if let Some(rbac) = rbac_config {
-        service = BoxCloneService::new(RbacService::new(service, rbac));
-    }
+        // Token passthrough (inject ClientToken for forward_auth backends)
+        let forward_namespaces: std::collections::HashSet<String> = config
+            .backends
+            .iter()
+            .filter(|b| b.forward_auth)
+            .map(|b| format!("{}{}", b.name, config.proxy.separator))
+            .collect();
 
-    // Token passthrough (inject ClientToken for forward_auth backends)
-    let forward_namespaces: std::collections::HashSet<String> = config
-        .backends
-        .iter()
-        .filter(|b| b.forward_auth)
-        .map(|b| format!("{}{}", b.name, config.proxy.separator))
-        .collect();
-
-    if !forward_namespaces.is_empty() {
-        tracing::info!(
-            backends = ?forward_namespaces,
-            "Enabling token passthrough for forward_auth backends"
-        );
-        service = BoxCloneService::new(crate::token::TokenPassthroughService::new(
-            service,
-            forward_namespaces,
-        ));
+        if !forward_namespaces.is_empty() {
+            tracing::info!(
+                backends = ?forward_namespaces,
+                "Enabling token passthrough for forward_auth backends"
+            );
+            service = BoxCloneService::new(crate::token::TokenPassthroughService::new(
+                service,
+                forward_namespaces,
+            ));
+        }
     }
 
     // Metrics
+    #[cfg(feature = "metrics")]
     if config.observability.metrics.enabled {
-        service = BoxCloneService::new(metrics::MetricsService::new(service));
+        service = BoxCloneService::new(crate::metrics::MetricsService::new(service));
     }
 
     // Audit logging
@@ -614,6 +621,7 @@ async fn apply_auth(config: &ProxyConfig, router: Router) -> Result<Router> {
                 let layer = AuthLayer::new(validator);
                 router.layer(layer)
             }
+            #[cfg(feature = "oauth")]
             AuthConfig::Jwt {
                 issuer,
                 audience,
@@ -642,6 +650,12 @@ async fn apply_auth(config: &ProxyConfig, router: Router) -> Result<Router> {
 
                 let layer = tower_mcp::oauth::OAuthLayer::new(validator, metadata);
                 router.layer(layer)
+            }
+            #[cfg(not(feature = "oauth"))]
+            AuthConfig::Jwt { .. } => {
+                anyhow::bail!(
+                    "JWT auth requires the 'oauth' feature. Rebuild with: cargo install mcp-proxy --features oauth"
+                );
             }
         }
     } else {


### PR DESCRIPTION
## Summary

- Add homebrew, docker, and pre-built binary installation instructions to README
- Switch dist profile from `lto = "thin"` to `lto = "fat"` + `strip = true`
- Reduces release binary size from ~19M to ~13M (~30% reduction)

## Test plan

- [x] `cargo build --profile dist` produces smaller binary
- [x] No runtime impact from stripping (only affects panic backtraces)