### PR TITLE
feat: add structured access logging middleware

### DIFF
--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -1,0 +1,154 @@
+//! Structured access logging middleware.
+//!
+//! Logs each MCP request with structured fields including method, tool/resource
+//! name, duration, and status. Uses the `mcp::access` tracing target so
+//! operators can filter access logs independently.
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use tower::Service;
+use tower_mcp::protocol::McpRequest;
+use tower_mcp::{RouterRequest, RouterResponse};
+
+/// Tower service that emits structured access log entries.
+#[derive(Clone)]
+pub struct AccessLogService<S> {
+    inner: S,
+}
+
+impl<S> AccessLogService<S> {
+    /// Create a new access log service wrapping `inner`.
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+/// Extract the tool, resource, or prompt name from an MCP request.
+fn request_target(req: &McpRequest) -> Option<&str> {
+    match req {
+        McpRequest::CallTool(params) => Some(&params.name),
+        McpRequest::ReadResource(params) => Some(&params.uri),
+        McpRequest::GetPrompt(params) => Some(&params.name),
+        _ => None,
+    }
+}
+
+impl<S> Service<RouterRequest> for AccessLogService<S>
+where
+    S: Service<RouterRequest, Response = RouterResponse, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
+    type Response = RouterResponse;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RouterRequest) -> Self::Future {
+        let method = req.inner.method_name().to_string();
+        let target = request_target(&req.inner).map(|s| s.to_string());
+        let start = Instant::now();
+        let fut = self.inner.call(req);
+
+        Box::pin(async move {
+            let result = fut.await;
+            let duration_ms = start.elapsed().as_millis() as u64;
+
+            let status = match &result {
+                Ok(resp) => {
+                    if resp.inner.is_ok() {
+                        "ok"
+                    } else {
+                        "error"
+                    }
+                }
+                Err(_) => "error",
+            };
+
+            match target {
+                Some(name) => {
+                    tracing::info!(
+                        target: "mcp::access",
+                        method = %method,
+                        target = %name,
+                        duration_ms = duration_ms,
+                        status = %status,
+                    );
+                }
+                None => {
+                    tracing::info!(
+                        target: "mcp::access",
+                        method = %method,
+                        duration_ms = duration_ms,
+                        status = %status,
+                    );
+                }
+            }
+
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_mcp::protocol::McpRequest;
+
+    use super::AccessLogService;
+    use crate::test_util::{ErrorMockService, MockService, call_service};
+
+    #[tokio::test]
+    async fn test_access_log_passes_through_list() {
+        let mock = MockService::with_tools(&["tool"]);
+        let mut svc = AccessLogService::new(mock);
+
+        let resp = call_service(&mut svc, McpRequest::ListTools(Default::default())).await;
+        assert!(resp.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_access_log_passes_through_tool_call() {
+        let mock = MockService::with_tools(&["tool"]);
+        let mut svc = AccessLogService::new(mock);
+
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "tool".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(resp.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_access_log_handles_errors() {
+        let mock = ErrorMockService;
+        let mut svc = AccessLogService::new(mock);
+
+        let resp = call_service(&mut svc, McpRequest::ListTools(Default::default())).await;
+        assert!(resp.inner.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_access_log_handles_ping() {
+        let mock = MockService::with_tools(&[]);
+        let mut svc = AccessLogService::new(mock);
+
+        let resp = call_service(&mut svc, McpRequest::Ping).await;
+        assert!(resp.inner.is_ok());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,6 +371,17 @@ pub struct ObservabilityConfig {
     /// OpenTelemetry distributed tracing configuration.
     #[serde(default)]
     pub tracing: TracingConfig,
+    /// Structured access logging configuration.
+    #[serde(default)]
+    pub access_log: AccessLogConfig,
+}
+
+/// Structured access log configuration.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct AccessLogConfig {
+    /// Enable structured access logging (default: false).
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 /// Prometheus metrics configuration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! Enable `hot_reload = true` in the config to watch the config file for new
 //! backends. The proxy will add them dynamically without restart.
 
+pub mod access_log;
 pub mod admin;
 pub mod admin_tools;
 pub mod alias;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -601,6 +601,12 @@ fn build_middleware_stack(
         service = BoxCloneService::new(crate::metrics::MetricsService::new(service));
     }
 
+    // Structured access logging
+    if config.observability.access_log.enabled {
+        tracing::info!("Access logging enabled (target: mcp::access)");
+        service = BoxCloneService::new(crate::access_log::AccessLogService::new(service));
+    }
+
     // Audit logging
     if config.observability.audit {
         tracing::info!("Audit logging enabled (target: mcp::audit)");


### PR DESCRIPTION
## Summary
- New `AccessLogService` middleware that logs every MCP request with structured fields
- Fields: method, target (tool/resource/prompt name), duration_ms, status
- Uses `mcp::access` tracing target for independent filtering
- Configurable via `[observability.access_log]` section

## Example config
```toml
[observability.access_log]
enabled = true
```

## Example log output
```
INFO mcp::access: method=tools/call target=github/create_issue duration_ms=142 status=ok
```

## Test plan
- [x] Passes through list requests
- [x] Passes through tool calls
- [x] Handles error responses
- [x] Handles ping
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes

Closes #78