### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-03-17
+
+### Bug Fixes
+
+- Access log includes backend name in structured output ([#144](https://github.com/joshrotenberg/mcp-proxy/pull/144))
+- --check warns about unset environment variables ([#145](https://github.com/joshrotenberg/mcp-proxy/pull/145))
+- Add missing REST API endpoints ([#150](https://github.com/joshrotenberg/mcp-proxy/pull/150))
+- Failover supports priority field for backend ordering ([#153](https://github.com/joshrotenberg/mcp-proxy/pull/153))
+- Add remaining REST API endpoints ([#155](https://github.com/joshrotenberg/mcp-proxy/pull/155))
+
+### Documentation
+
+- Add runnable examples for library embedding ([#127](https://github.com/joshrotenberg/mcp-proxy/pull/127))
+- Comprehensive config.example.toml with all options documented ([#142](https://github.com/joshrotenberg/mcp-proxy/pull/142))
+
+### Features
+
+- Add --check config validation flag ([#89](https://github.com/joshrotenberg/mcp-proxy/pull/89))
+- Add structured access logging middleware ([#91](https://github.com/joshrotenberg/mcp-proxy/pull/91))
+- Add glob pattern support for tool filtering ([#90](https://github.com/joshrotenberg/mcp-proxy/pull/90))
+- Expose middleware as composable tower::Layer implementations ([#98](https://github.com/joshrotenberg/mcp-proxy/pull/98))
+- Add backend failover routing ([#99](https://github.com/joshrotenberg/mcp-proxy/pull/99))
+- Add global rate limiting across all backends ([#108](https://github.com/joshrotenberg/mcp-proxy/pull/108))
+- Support .mcp.json as a backend config source ([#109](https://github.com/joshrotenberg/mcp-proxy/pull/109))
+- Complete hot reload with backend removal and modification ([#110](https://github.com/joshrotenberg/mcp-proxy/pull/110))
+- Add ProxyBuilder for programmatic proxy construction ([#111](https://github.com/joshrotenberg/mcp-proxy/pull/111))
+- Add REST management API for backend lifecycle ([#112](https://github.com/joshrotenberg/mcp-proxy/pull/112))
+- Integrate utoipa for OpenAPI spec generation ([#128](https://github.com/joshrotenberg/mcp-proxy/pull/128))
+- Add cache backend config and validation ([#133](https://github.com/joshrotenberg/mcp-proxy/pull/133))
+- Add composite/parallel tool fan-out middleware ([#135](https://github.com/joshrotenberg/mcp-proxy/pull/135))
+- Add parameter hiding and renaming for tool customization ([#134](https://github.com/joshrotenberg/mcp-proxy/pull/134))
+- Annotation-aware tool filtering ([#137](https://github.com/joshrotenberg/mcp-proxy/pull/137))
+- Add per-token tool scoping for bearer auth ([#138](https://github.com/joshrotenberg/mcp-proxy/pull/138))
+- Add WebSocket backend transport support ([#139](https://github.com/joshrotenberg/mcp-proxy/pull/139))
+- BM25-based tool discovery and search ([#140](https://github.com/joshrotenberg/mcp-proxy/pull/140))
+- Add OAuth 2.1 authorization flow support ([#141](https://github.com/joshrotenberg/mcp-proxy/pull/141))
+- Support YAML config format ([#146](https://github.com/joshrotenberg/mcp-proxy/pull/146))
+- Ergonomic per-backend builder methods for ProxyBuilder ([#147](https://github.com/joshrotenberg/mcp-proxy/pull/147))
+- Regex support for tool filtering (re: prefix) ([#149](https://github.com/joshrotenberg/mcp-proxy/pull/149))
+- Pure .mcp.json mode (no TOML config needed) ([#148](https://github.com/joshrotenberg/mcp-proxy/pull/148))
+- CacheLayer tower::Layer implementation ([#151](https://github.com/joshrotenberg/mcp-proxy/pull/151))
+- Search-mode tool exposure for large tool sets ([#154](https://github.com/joshrotenberg/mcp-proxy/pull/154))
+- Bump tower-mcp 0.8.8, add session and circuit breaker admin endpoints ([#156](https://github.com/joshrotenberg/mcp-proxy/pull/156))
+- Implement Redis and SQLite cache backends ([#157](https://github.com/joshrotenberg/mcp-proxy/pull/157))
+
+### Miscellaneous Tasks
+
+- Move scratch config files to examples/ ([#143](https://github.com/joshrotenberg/mcp-proxy/pull/143))
+
+### Testing
+
+- Add comprehensive end-to-end integration test suite ([#94](https://github.com/joshrotenberg/mcp-proxy/pull/94))
+- HTTP transport-level E2E tests ([#152](https://github.com/joshrotenberg/mcp-proxy/pull/152))
+
+
+
 ## [0.1.1] - 2026-03-08
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Standalone MCP proxy -- config-driven reverse proxy with auth, rate limiting, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `mcp-proxy` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ObservabilityConfig.access_log in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:663
  field BackendFilter.hide_destructive in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:814
  field BackendFilter.read_only_only in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:816
  field ProxySettings.import_backends in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:97
  field ProxySettings.rate_limit in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:99
  field ProxySettings.tool_discovery in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:104
  field ProxySettings.tool_exposure in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:113
  field BackendConfig.param_overrides in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:222
  field BackendConfig.hide_destructive in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:243
  field BackendConfig.read_only_only in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:246
  field BackendConfig.failover_for in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:250
  field BackendConfig.priority in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:256
  field ProxyConfig.cache in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:28
  field ProxyConfig.composite_tools in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:34
  field ProxyConfig.cache in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:28
  field ProxyConfig.composite_tools in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:34

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field scoped_tokens of variant AuthConfig::Bearer in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:436

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant TransportType:Websocket in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:276
  variant AuthConfig:OAuth in /tmp/.tmpVyxo2U/mcp-proxy/src/config.rs:457

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  mcp_proxy::admin::admin_router now takes 6 parameters instead of 4, in /tmp/.tmpVyxo2U/mcp-proxy/src/admin.rs:599
  mcp_proxy::reload::spawn_config_watcher now takes 3 parameters instead of 2, in /tmp/.tmpVyxo2U/mcp-proxy/src/reload.rs:21
  mcp_proxy::admin_tools::register_admin_tools now takes 5 parameters instead of 4, in /tmp/.tmpVyxo2U/mcp-proxy/src/admin_tools.rs:62

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  mcp_proxy::cache::CacheService::new now takes 3 parameters instead of 2, in /tmp/.tmpVyxo2U/mcp-proxy/src/cache.rs:477
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2026-03-17

### Bug Fixes

- Access log includes backend name in structured output ([#144](https://github.com/joshrotenberg/mcp-proxy/pull/144))
- --check warns about unset environment variables ([#145](https://github.com/joshrotenberg/mcp-proxy/pull/145))
- Add missing REST API endpoints ([#150](https://github.com/joshrotenberg/mcp-proxy/pull/150))
- Failover supports priority field for backend ordering ([#153](https://github.com/joshrotenberg/mcp-proxy/pull/153))
- Add remaining REST API endpoints ([#155](https://github.com/joshrotenberg/mcp-proxy/pull/155))

### Documentation

- Add runnable examples for library embedding ([#127](https://github.com/joshrotenberg/mcp-proxy/pull/127))
- Comprehensive config.example.toml with all options documented ([#142](https://github.com/joshrotenberg/mcp-proxy/pull/142))

### Features

- Add --check config validation flag ([#89](https://github.com/joshrotenberg/mcp-proxy/pull/89))
- Add structured access logging middleware ([#91](https://github.com/joshrotenberg/mcp-proxy/pull/91))
- Add glob pattern support for tool filtering ([#90](https://github.com/joshrotenberg/mcp-proxy/pull/90))
- Expose middleware as composable tower::Layer implementations ([#98](https://github.com/joshrotenberg/mcp-proxy/pull/98))
- Add backend failover routing ([#99](https://github.com/joshrotenberg/mcp-proxy/pull/99))
- Add global rate limiting across all backends ([#108](https://github.com/joshrotenberg/mcp-proxy/pull/108))
- Support .mcp.json as a backend config source ([#109](https://github.com/joshrotenberg/mcp-proxy/pull/109))
- Complete hot reload with backend removal and modification ([#110](https://github.com/joshrotenberg/mcp-proxy/pull/110))
- Add ProxyBuilder for programmatic proxy construction ([#111](https://github.com/joshrotenberg/mcp-proxy/pull/111))
- Add REST management API for backend lifecycle ([#112](https://github.com/joshrotenberg/mcp-proxy/pull/112))
- Integrate utoipa for OpenAPI spec generation ([#128](https://github.com/joshrotenberg/mcp-proxy/pull/128))
- Add cache backend config and validation ([#133](https://github.com/joshrotenberg/mcp-proxy/pull/133))
- Add composite/parallel tool fan-out middleware ([#135](https://github.com/joshrotenberg/mcp-proxy/pull/135))
- Add parameter hiding and renaming for tool customization ([#134](https://github.com/joshrotenberg/mcp-proxy/pull/134))
- Annotation-aware tool filtering ([#137](https://github.com/joshrotenberg/mcp-proxy/pull/137))
- Add per-token tool scoping for bearer auth ([#138](https://github.com/joshrotenberg/mcp-proxy/pull/138))
- Add WebSocket backend transport support ([#139](https://github.com/joshrotenberg/mcp-proxy/pull/139))
- BM25-based tool discovery and search ([#140](https://github.com/joshrotenberg/mcp-proxy/pull/140))
- Add OAuth 2.1 authorization flow support ([#141](https://github.com/joshrotenberg/mcp-proxy/pull/141))
- Support YAML config format ([#146](https://github.com/joshrotenberg/mcp-proxy/pull/146))
- Ergonomic per-backend builder methods for ProxyBuilder ([#147](https://github.com/joshrotenberg/mcp-proxy/pull/147))
- Regex support for tool filtering (re: prefix) ([#149](https://github.com/joshrotenberg/mcp-proxy/pull/149))
- Pure .mcp.json mode (no TOML config needed) ([#148](https://github.com/joshrotenberg/mcp-proxy/pull/148))
- CacheLayer tower::Layer implementation ([#151](https://github.com/joshrotenberg/mcp-proxy/pull/151))
- Search-mode tool exposure for large tool sets ([#154](https://github.com/joshrotenberg/mcp-proxy/pull/154))
- Bump tower-mcp 0.8.8, add session and circuit breaker admin endpoints ([#156](https://github.com/joshrotenberg/mcp-proxy/pull/156))
- Implement Redis and SQLite cache backends ([#157](https://github.com/joshrotenberg/mcp-proxy/pull/157))

### Miscellaneous Tasks

- Move scratch config files to examples/ ([#143](https://github.com/joshrotenberg/mcp-proxy/pull/143))

### Testing

- Add comprehensive end-to-end integration test suite ([#94](https://github.com/joshrotenberg/mcp-proxy/pull/94))
- HTTP transport-level E2E tests ([#152](https://github.com/joshrotenberg/mcp-proxy/pull/152))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).