### PR TITLE
feat: expose middleware as composable tower::Layer implementations

### DIFF
--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -10,9 +10,28 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::protocol::McpRequest;
 use tower_mcp::{RouterRequest, RouterResponse};
+
+/// Tower layer that produces an [`AccessLogService`].
+#[derive(Clone, Default)]
+pub struct AccessLogLayer;
+
+impl AccessLogLayer {
+    /// Create a new access log layer.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for AccessLogLayer {
+    type Service = AccessLogService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AccessLogService::new(inner)
+    }
+}
 
 /// Tower service that emits structured access log entries.
 #[derive(Clone)]

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -10,9 +10,45 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::router::{RouterRequest, RouterResponse};
 use tower_mcp_types::protocol::{McpRequest, McpResponse};
+
+/// Tower layer that produces an [`AliasService`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tower::ServiceBuilder;
+/// use mcp_proxy::alias::{AliasLayer, AliasMap};
+///
+/// let aliases = AliasMap::new(vec![
+///     ("math/".into(), "add".into(), "sum".into()),
+/// ]).unwrap();
+///
+/// let service = ServiceBuilder::new()
+///     .layer(AliasLayer::new(aliases))
+///     .service(proxy);
+/// ```
+#[derive(Clone)]
+pub struct AliasLayer {
+    aliases: AliasMap,
+}
+
+impl AliasLayer {
+    /// Create a new alias layer with the given alias map.
+    pub fn new(aliases: AliasMap) -> Self {
+        Self { aliases }
+    }
+}
+
+impl<S> Layer<S> for AliasLayer {
+    type Service = AliasService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AliasService::new(inner, self.aliases.clone())
+    }
+}
 
 /// Resolved alias mappings for all backends.
 #[derive(Clone)]

--- a/src/canary.rs
+++ b/src/canary.rs
@@ -40,9 +40,39 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::router::{Extensions, RouterRequest, RouterResponse};
 use tower_mcp_types::protocol::{CallToolParams, GetPromptParams, McpRequest, ReadResourceParams};
+
+/// Tower layer that produces a [`CanaryService`].
+#[derive(Clone)]
+pub struct CanaryLayer {
+    canaries: HashMap<String, (String, u32, u32)>,
+    separator: String,
+}
+
+impl CanaryLayer {
+    /// Create a new canary routing layer.
+    ///
+    /// `canaries` maps primary backend names to `(canary_name, primary_weight, canary_weight)`.
+    pub fn new(
+        canaries: HashMap<String, (String, u32, u32)>,
+        separator: impl Into<String>,
+    ) -> Self {
+        Self {
+            canaries,
+            separator: separator.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for CanaryLayer {
+    type Service = CanaryService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CanaryService::new(inner, self.canaries.clone(), &self.separator)
+    }
+}
 
 /// Mapping from a primary backend namespace to its canary configuration.
 #[derive(Debug, Clone)]

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -12,9 +12,34 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use tokio::sync::{Mutex, broadcast};
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::router::{RouterRequest, RouterResponse};
 use tower_mcp_types::protocol::McpRequest;
+
+/// Tower layer that produces a [`CoalesceService`].
+#[derive(Clone)]
+pub struct CoalesceLayer;
+
+impl CoalesceLayer {
+    /// Create a new request coalescing layer.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CoalesceLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for CoalesceLayer {
+    type Service = CoalesceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CoalesceService::new(inner)
+    }
+}
 
 /// Tower service that coalesces identical in-flight requests.
 #[derive(Clone)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -9,13 +9,45 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 
 use tower_mcp::protocol::{McpRequest, McpResponse};
 use tower_mcp::{RouterRequest, RouterResponse};
 use tower_mcp_types::JsonRpcError;
 
 use crate::config::BackendFilter;
+
+/// Tower layer that produces a [`CapabilityFilterService`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tower::ServiceBuilder;
+/// use mcp_proxy::filter::CapabilityFilterLayer;
+///
+/// let service = ServiceBuilder::new()
+///     .layer(CapabilityFilterLayer::new(filters))
+///     .service(proxy);
+/// ```
+#[derive(Clone)]
+pub struct CapabilityFilterLayer {
+    filters: Vec<BackendFilter>,
+}
+
+impl CapabilityFilterLayer {
+    /// Create a new capability filter layer with the given filter rules.
+    pub fn new(filters: Vec<BackendFilter>) -> Self {
+        Self { filters }
+    }
+}
+
+impl<S> Layer<S> for CapabilityFilterLayer {
+    type Service = CapabilityFilterService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CapabilityFilterService::new(inner, self.filters.clone())
+    }
+}
 
 /// Middleware that filters capabilities from proxy responses.
 #[derive(Clone)]

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -35,9 +35,30 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::router::{RouterRequest, RouterResponse};
 use tower_mcp_types::protocol::McpRequest;
+
+/// Tower layer that produces an [`InjectArgsService`].
+#[derive(Clone)]
+pub struct InjectArgsLayer {
+    rules: Vec<InjectionRules>,
+}
+
+impl InjectArgsLayer {
+    /// Create a new argument injection layer.
+    pub fn new(rules: Vec<InjectionRules>) -> Self {
+        Self { rules }
+    }
+}
+
+impl<S> Layer<S> for InjectArgsLayer {
+    type Service = InjectArgsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InjectArgsService::new(inner, self.rules.clone())
+    }
+}
 
 /// Per-tool injection rule.
 #[derive(Debug, Clone)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,8 +10,27 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use metrics::{counter, histogram};
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::{RouterRequest, RouterResponse};
+
+/// Tower layer that produces a [`MetricsService`].
+#[derive(Clone, Default)]
+pub struct MetricsLayer;
+
+impl MetricsLayer {
+    /// Create a new metrics layer.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService::new(inner)
+    }
+}
 
 /// Tower service that records request metrics.
 #[derive(Clone)]

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -37,9 +37,36 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 use tower_mcp::router::{Extensions, RouterRequest, RouterResponse};
 use tower_mcp_types::protocol::{CallToolParams, GetPromptParams, McpRequest, ReadResourceParams};
+
+/// Tower layer that produces a [`MirrorService`].
+#[derive(Clone)]
+pub struct MirrorLayer {
+    mirrors: HashMap<String, (String, u32)>,
+    separator: String,
+}
+
+impl MirrorLayer {
+    /// Create a new mirror layer.
+    ///
+    /// `mirrors` maps source backend names to `(mirror_name, percent)`.
+    pub fn new(mirrors: HashMap<String, (String, u32)>, separator: impl Into<String>) -> Self {
+        Self {
+            mirrors,
+            separator: separator.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for MirrorLayer {
+    type Service = MirrorService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MirrorService::new(inner, self.mirrors.clone(), &self.separator)
+    }
+}
 
 /// Mapping from a source backend namespace to its mirror configuration.
 #[derive(Debug, Clone)]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -8,9 +8,30 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use tower::Service;
+use tower::{Layer, Service};
 
 use tower_mcp::protocol::McpRequest;
+
+/// Tower layer that produces a [`ValidationService`].
+#[derive(Clone)]
+pub struct ValidationLayer {
+    config: ValidationConfig,
+}
+
+impl ValidationLayer {
+    /// Create a new validation layer.
+    pub fn new(config: ValidationConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl<S> Layer<S> for ValidationLayer {
+    type Service = ValidationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ValidationService::new(inner, self.config.clone())
+    }
+}
 use tower_mcp::{RouterRequest, RouterResponse};
 use tower_mcp_types::JsonRpcError;
 


### PR DESCRIPTION
## Summary
Adds `tower::Layer` implementations for all middleware components, enabling standard tower composition patterns for library users.

**New layers:**
- `CapabilityFilterLayer` / `AliasLayer` / `InjectArgsLayer`
- `ValidationLayer` / `CoalesceLayer` / `AccessLogLayer`
- `MetricsLayer` / `MirrorLayer` / `CanaryLayer`

## Example
```rust
use tower::ServiceBuilder;
use mcp_proxy::filter::CapabilityFilterLayer;
use mcp_proxy::alias::AliasLayer;

let service = ServiceBuilder::new()
    .layer(CapabilityFilterLayer::new(filters))
    .layer(AliasLayer::new(aliases))
    .service(proxy);
```

## Test plan
- [x] 129 unit tests pass
- [x] 21 integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo doc --no-deps --all-features` builds
- [x] `cargo test --doc --all-features` passes

Closes #96