### PR TITLE
feat: add backend failover routing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,10 @@ pub struct BackendConfig {
     /// Capability filtering: hide these prompts (denylist)
     #[serde(default)]
     pub hide_prompts: Vec<String>,
+    /// Failover: name of the primary backend this is a failover for.
+    /// When set, this backend's tools are hidden and requests are only
+    /// routed here when the primary returns an error.
+    pub failover_for: Option<String>,
     /// Canary routing: name of the primary backend this is a canary for.
     /// When set, this backend's tools are hidden and requests targeting
     /// the primary are probabilistically routed here based on weight.
@@ -577,13 +581,13 @@ impl BackendConfig {
     /// Build a [`BackendFilter`] from this backend's expose/hide lists.
     /// Returns `None` if no filtering is configured.
     ///
-    /// Canary backends automatically hide all capabilities so their tools
-    /// don't appear in `ListTools` responses (traffic reaches them via the
-    /// canary routing middleware, not direct tool calls).
+    /// Canary and failover backends automatically hide all capabilities so
+    /// their tools don't appear in `ListTools` responses (traffic reaches
+    /// them via routing middleware, not direct tool calls).
     pub fn build_filter(&self, separator: &str) -> Option<BackendFilter> {
-        // Canary backends hide all capabilities -- tools are accessed via
-        // the canary routing middleware rewriting the primary namespace.
-        if self.canary_of.is_some() {
+        // Canary and failover backends hide all capabilities -- tools are
+        // accessed via routing middleware rewriting the primary namespace.
+        if self.canary_of.is_some() || self.failover_for.is_some() {
             return Some(BackendFilter {
                 namespace: format!("{}{}", self.name, separator),
                 tool_filter: NameFilter::AllowList(HashSet::new()),
@@ -762,6 +766,25 @@ impl ProxyConfig {
                 if source == &backend.name {
                     anyhow::bail!(
                         "backend '{}': mirror_of cannot reference itself",
+                        backend.name
+                    );
+                }
+            }
+        }
+
+        // Validate failover_for references
+        for backend in &self.backends {
+            if let Some(ref primary) = backend.failover_for {
+                if !backend_names.contains(primary.as_str()) {
+                    anyhow::bail!(
+                        "backend '{}': failover_for references unknown backend '{}'",
+                        backend.name,
+                        primary
+                    );
+                }
+                if primary == &backend.name {
+                    anyhow::bail!(
+                        "backend '{}': failover_for cannot reference itself",
                         backend.name
                     );
                 }

--- a/src/failover.rs
+++ b/src/failover.rs
@@ -1,0 +1,323 @@
+//! Backend failover middleware.
+//!
+//! Routes requests to a primary backend, automatically falling over to a
+//! secondary backend when the primary returns an error. Unlike canary routing
+//! (which is probabilistic), failover is deterministic: the secondary is only
+//! used when the primary fails.
+//!
+//! # Configuration
+//!
+//! ```toml
+//! [[backends]]
+//! name = "api"
+//! transport = "http"
+//! url = "http://primary:8080"
+//!
+//! [[backends]]
+//! name = "api-backup"
+//! transport = "http"
+//! url = "http://secondary:8080"
+//! failover_for = "api"
+//! ```
+//!
+//! # How it works
+//!
+//! 1. Request arrives targeting `api/search`
+//! 2. Request is forwarded to the `api` backend
+//! 3. If `api` returns an error, the request is retried against `api-backup/search`
+//! 4. Failover backend tools are hidden from `ListTools` (like canary backends)
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tower::{Layer, Service};
+use tower_mcp::router::{Extensions, RouterRequest, RouterResponse};
+use tower_mcp_types::protocol::{CallToolParams, GetPromptParams, McpRequest, ReadResourceParams};
+
+/// Resolved failover mapping for a single primary backend.
+#[derive(Debug, Clone)]
+struct FailoverMapping {
+    /// Primary namespace prefix (e.g. "api/").
+    primary_prefix: String,
+    /// Failover namespace prefix (e.g. "api-backup/").
+    failover_prefix: String,
+}
+
+/// Tower layer that produces a [`FailoverService`].
+#[derive(Clone)]
+pub struct FailoverLayer {
+    failovers: HashMap<String, String>,
+    separator: String,
+}
+
+impl FailoverLayer {
+    /// Create a new failover layer.
+    ///
+    /// `failovers` maps primary backend names to failover backend names.
+    pub fn new(failovers: HashMap<String, String>, separator: impl Into<String>) -> Self {
+        Self {
+            failovers,
+            separator: separator.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for FailoverLayer {
+    type Service = FailoverService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        FailoverService::new(inner, self.failovers.clone(), &self.separator)
+    }
+}
+
+/// Tower service that fails over to a secondary backend on primary error.
+#[derive(Clone)]
+pub struct FailoverService<S> {
+    inner: S,
+    mappings: Arc<Vec<FailoverMapping>>,
+}
+
+impl<S> FailoverService<S> {
+    /// Create a new failover service.
+    ///
+    /// `failovers` maps primary backend names to failover backend names.
+    pub fn new(inner: S, failovers: HashMap<String, String>, separator: &str) -> Self {
+        let mappings = failovers
+            .into_iter()
+            .map(|(primary, failover)| FailoverMapping {
+                primary_prefix: format!("{primary}{separator}"),
+                failover_prefix: format!("{failover}{separator}"),
+            })
+            .collect();
+
+        Self {
+            inner,
+            mappings: Arc::new(mappings),
+        }
+    }
+}
+
+/// Rewrite a request's namespace from primary to failover.
+fn rewrite_request(req: &McpRequest, primary_prefix: &str, failover_prefix: &str) -> McpRequest {
+    match req {
+        McpRequest::CallTool(params) => {
+            if let Some(local) = params.name.strip_prefix(primary_prefix) {
+                McpRequest::CallTool(CallToolParams {
+                    name: format!("{failover_prefix}{local}"),
+                    arguments: params.arguments.clone(),
+                    meta: params.meta.clone(),
+                    task: params.task.clone(),
+                })
+            } else {
+                req.clone()
+            }
+        }
+        McpRequest::ReadResource(params) => {
+            if let Some(local) = params.uri.strip_prefix(primary_prefix) {
+                McpRequest::ReadResource(ReadResourceParams {
+                    uri: format!("{failover_prefix}{local}"),
+                    meta: params.meta.clone(),
+                })
+            } else {
+                req.clone()
+            }
+        }
+        McpRequest::GetPrompt(params) => {
+            if let Some(local) = params.name.strip_prefix(primary_prefix) {
+                McpRequest::GetPrompt(GetPromptParams {
+                    name: format!("{failover_prefix}{local}"),
+                    arguments: params.arguments.clone(),
+                    meta: params.meta.clone(),
+                })
+            } else {
+                req.clone()
+            }
+        }
+        other => other.clone(),
+    }
+}
+
+impl<S> Service<RouterRequest> for FailoverService<S>
+where
+    S: Service<RouterRequest, Response = RouterResponse, Error = Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
+    type Response = RouterResponse;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RouterRequest) -> Self::Future {
+        let mappings = Arc::clone(&self.mappings);
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            // Find if this request targets a primary that has a failover
+            let mapping = mappings.iter().find(|m| match &req.inner {
+                McpRequest::CallTool(p) => p.name.starts_with(&m.primary_prefix),
+                McpRequest::ReadResource(p) => p.uri.starts_with(&m.primary_prefix),
+                McpRequest::GetPrompt(p) => p.name.starts_with(&m.primary_prefix),
+                _ => false,
+            });
+
+            let mapping = match mapping {
+                Some(m) => m.clone(),
+                None => {
+                    // No failover configured for this request, pass through
+                    return inner.call(req).await;
+                }
+            };
+
+            // Try primary
+            let primary_resp = inner.call(req.clone()).await?;
+
+            // If primary succeeded, return it
+            if primary_resp.inner.is_ok() {
+                return Ok(primary_resp);
+            }
+
+            // Primary failed -- attempt failover
+            let failover_request = rewrite_request(
+                &req.inner,
+                &mapping.primary_prefix,
+                &mapping.failover_prefix,
+            );
+
+            tracing::warn!(
+                primary = %mapping.primary_prefix.trim_end_matches('/'),
+                failover = %mapping.failover_prefix.trim_end_matches('/'),
+                "Primary backend failed, attempting failover"
+            );
+
+            let failover_req = RouterRequest {
+                id: req.id,
+                inner: failover_request,
+                extensions: Extensions::new(),
+            };
+
+            inner.call(failover_req).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_mcp::protocol::{McpRequest, McpResponse};
+
+    use super::FailoverService;
+    use crate::test_util::{MockService, call_service};
+
+    fn make_failover_svc(mock: MockService) -> FailoverService<MockService> {
+        let failovers = [("primary".to_string(), "backup".to_string())]
+            .into_iter()
+            .collect();
+        FailoverService::new(mock, failovers, "/")
+    }
+
+    #[tokio::test]
+    async fn test_failover_passes_through_when_no_mapping() {
+        let mock = MockService::with_tools(&["other/tool"]);
+        let mut svc = make_failover_svc(mock);
+
+        let resp = call_service(&mut svc, McpRequest::ListTools(Default::default())).await;
+        assert!(resp.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_failover_passes_through_on_success() {
+        let mock = MockService::with_tools(&["primary/tool", "backup/tool"]);
+        let mut svc = make_failover_svc(mock);
+
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "primary/tool".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(resp.inner.is_ok(), "successful primary should pass through");
+    }
+
+    #[tokio::test]
+    async fn test_failover_retries_on_primary_error() {
+        // Create a mock that returns errors for "primary/" calls
+        // but succeeds for "backup/" calls
+        use std::convert::Infallible;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use tower::Service;
+        use tower_mcp::protocol::CallToolResult;
+        use tower_mcp::router::{RouterRequest, RouterResponse};
+
+        #[derive(Clone)]
+        struct FailPrimaryMock;
+
+        impl Service<RouterRequest> for FailPrimaryMock {
+            type Response = RouterResponse;
+            type Error = Infallible;
+            type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: RouterRequest) -> Self::Future {
+                let id = req.id.clone();
+                Box::pin(async move {
+                    let inner = match &req.inner {
+                        McpRequest::CallTool(params) if params.name.starts_with("primary/") => {
+                            Err(tower_mcp_types::JsonRpcError {
+                                code: -32603,
+                                message: "primary down".to_string(),
+                                data: None,
+                            })
+                        }
+                        McpRequest::CallTool(params) if params.name.starts_with("backup/") => {
+                            Ok(McpResponse::CallTool(CallToolResult::text("from backup")))
+                        }
+                        _ => Ok(McpResponse::Pong(Default::default())),
+                    };
+                    Ok(RouterResponse { id, inner })
+                })
+            }
+        }
+
+        let failovers = [("primary".to_string(), "backup".to_string())]
+            .into_iter()
+            .collect();
+        let mut svc = FailoverService::new(FailPrimaryMock, failovers, "/");
+
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "primary/tool".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        match resp.inner.unwrap() {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "from backup");
+            }
+            other => panic!("expected CallTool, got: {:?}", other),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod cache;
 pub mod canary;
 pub mod coalesce;
 pub mod config;
+pub mod failover;
 pub mod filter;
 pub mod inject;
 #[cfg(feature = "metrics")]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -444,6 +444,32 @@ fn build_middleware_stack(
         ));
     }
 
+    // Failover routing (deterministic fallback on primary error)
+    let failover_mappings: std::collections::HashMap<String, String> = config
+        .backends
+        .iter()
+        .filter_map(|b| {
+            b.failover_for
+                .as_ref()
+                .map(|primary| (primary.clone(), b.name.clone()))
+        })
+        .collect();
+
+    if !failover_mappings.is_empty() {
+        for (primary, failover) in &failover_mappings {
+            tracing::info!(
+                primary = %primary,
+                failover = %failover,
+                "Enabling failover routing"
+            );
+        }
+        service = BoxCloneService::new(crate::failover::FailoverService::new(
+            service,
+            failover_mappings,
+            &config.proxy.separator,
+        ));
+    }
+
     // Traffic mirroring (sends cloned requests through the proxy)
     let mirror_mappings: std::collections::HashMap<String, (String, u32)> = config
         .backends


### PR DESCRIPTION
## Summary
- Deterministic failover: when a primary backend returns an error, the request is automatically retried against a configured failover backend
- Unlike canary routing (probabilistic), failover only triggers on primary error
- Failover backend tools are hidden from ListTools (like canary backends)
- Includes FailoverLayer for library users

## Config
```toml
[[backends]]
name = "api"
transport = "http"
url = "http://primary:8080"

[[backends]]
name = "api-backup"
transport = "http"
url = "http://secondary:8080"
failover_for = "api"
```

## Test plan
- [x] 3 new unit tests (pass-through, success pass-through, failover on error)
- [x] Config validation for failover_for references (unknown backend, self-reference)
- [x] 132 unit tests pass
- [x] 21 integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo doc --no-deps --all-features` builds
- [x] `cargo test --doc --all-features` passes

Closes #79