### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-03-18
+
+### Testing
+
+- Add examples for library and config scenarios ([#170](https://github.com/joshrotenberg/mcp-proxy/pull/170))
+- Add unit tests for admin_tools, coalesce, and reload modules ([#172](https://github.com/joshrotenberg/mcp-proxy/pull/172))
+- Add unit tests for ws_transport, discovery, and skills modules ([#171](https://github.com/joshrotenberg/mcp-proxy/pull/171))
+
+
+
 ## [0.3.0] - 2026-03-18
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.90"
 description = "Standalone MCP proxy -- config-driven reverse proxy with auth, rate limiting, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1] - 2026-03-18

### Testing

- Add examples for library and config scenarios ([#170](https://github.com/joshrotenberg/mcp-proxy/pull/170))
- Add unit tests for admin_tools, coalesce, and reload modules ([#172](https://github.com/joshrotenberg/mcp-proxy/pull/172))
- Add unit tests for ws_transport, discovery, and skills modules ([#171](https://github.com/joshrotenberg/mcp-proxy/pull/171))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).