### PR TITLE
test: add examples for library and config scenarios

### DIFF
--- a/examples/canary-rollout.toml
+++ b/examples/canary-rollout.toml
@@ -1,0 +1,44 @@
+# Canary rollout -- gradually shift traffic to a new backend version.
+# Start at 5% canary weight, increase as confidence grows.
+
+[proxy]
+name = "canary-proxy"
+[proxy.listen]
+host = "0.0.0.0"
+port = 8080
+
+# Primary backend (receives ~95% of traffic)
+[[backends]]
+name = "api"
+transport = "http"
+url = "http://api-v1:8080"
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.3
+minimum_calls = 10
+wait_duration_seconds = 30
+
+# Canary backend (receives ~5% of traffic)
+[[backends]]
+name = "api-canary"
+transport = "http"
+url = "http://api-v2:8080"
+canary_of = "api"
+weight = 5              # 5% of traffic to canary
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.1    # Stricter threshold for canary
+minimum_calls = 5
+wait_duration_seconds = 60
+
+# Mirror traffic to a shadow backend for testing (fire-and-forget)
+[[backends]]
+name = "api-shadow"
+transport = "http"
+url = "http://api-v3-beta:8080"
+mirror_of = "api"
+mirror_percent = 1      # 1% of traffic mirrored
+
+[observability]
+audit = true            # Audit all requests during rollout
+log_level = "info"

--- a/examples/multi-instance-redis.toml
+++ b/examples/multi-instance-redis.toml
@@ -1,0 +1,44 @@
+# Multi-instance deployment with Redis cache
+# Run multiple proxy instances behind a load balancer, sharing cache via Redis.
+
+[proxy]
+name = "multi-proxy"
+[proxy.listen]
+host = "0.0.0.0"
+port = 8080
+
+# External Redis cache -- shared across all instances
+[cache]
+backend = "redis"
+url = "redis://redis:6379"
+prefix = "mcp-proxy:"
+
+[[backends]]
+name = "api"
+transport = "http"
+url = "http://api:8080"
+
+# Per-backend cache TTLs (stored in Redis)
+[backends.cache]
+resource_ttl_seconds = 300
+tool_ttl_seconds = 60
+max_entries = 5000
+
+[[backends]]
+name = "search"
+transport = "http"
+url = "http://search:8080"
+
+[backends.cache]
+tool_ttl_seconds = 120
+max_entries = 1000
+
+[observability]
+log_level = "info"
+json_logs = true    # Structured logs for aggregation
+
+[observability.metrics]
+enabled = true      # Prometheus at /admin/metrics
+
+[security]
+admin_token = "${ADMIN_TOKEN}"   # Protect admin API in production

--- a/examples/oauth_setup.rs
+++ b/examples/oauth_setup.rs
@@ -1,0 +1,58 @@
+//! OAuth 2.1 authentication setup -- connect to an identity provider.
+//!
+//! Demonstrates configuring OAuth 2.1 auth with auto-discovery from an
+//! issuer URL. The proxy automatically discovers JWKS and introspection
+//! endpoints via RFC 8414 metadata.
+//!
+//! Run with: `cargo run --example oauth_setup`
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // OAuth config with auto-discovery
+    let config = mcp_proxy::ProxyConfig::parse(
+        r#"
+        [proxy]
+        name = "oauth-proxy"
+        [proxy.listen]
+        host = "0.0.0.0"
+        port = 8080
+
+        [[backends]]
+        name = "api"
+        transport = "stdio"
+        command = "echo"
+
+        # OAuth 2.1 with auto-discovery from issuer
+        [auth]
+        type = "oauth"
+        issuer = "https://accounts.google.com"
+        audience = "mcp-proxy"
+        # token_validation = "jwt"        # default: validate JWTs via JWKS
+        # token_validation = "introspection"  # validate opaque tokens
+        # token_validation = "both"       # try JWT first, fall back to introspection
+
+        # For introspection mode, provide client credentials:
+        # client_id = "my-client-id"
+        # client_secret = "${OAUTH_CLIENT_SECRET}"
+
+        # RBAC roles (optional, same as JWT auth)
+        # [[auth.roles]]
+        # name = "reader"
+        # allow_tools = ["api/read_*"]
+        #
+        # [auth.role_mapping]
+        # claim = "scope"
+        # mapping = { "mcp:read" = "reader" }
+        "#,
+    )?;
+
+    println!("OAuth config parsed successfully:");
+    println!("  Auth type: OAuth 2.1");
+    println!("  Backends: {}", config.backends.len());
+
+    // In production, build and serve:
+    // let proxy = mcp_proxy::Proxy::from_config(config).await?;
+    // proxy.serve().await?;
+
+    Ok(())
+}

--- a/examples/resilience.rs
+++ b/examples/resilience.rs
@@ -1,0 +1,85 @@
+//! Resilience patterns -- configure protection for unreliable backends.
+//!
+//! Demonstrates the full resilience stack: timeout, circuit breaker,
+//! rate limit, retry, caching, and failover for a production deployment.
+//!
+//! Run with: `cargo run --example resilience`
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = mcp_proxy::ProxyConfig::parse(
+        r#"
+        [proxy]
+        name = "resilient-proxy"
+        [proxy.listen]
+
+        # Primary backend with full resilience stack
+        [[backends]]
+        name = "api"
+        transport = "http"
+        url = "http://api:8080"
+
+        [backends.timeout]
+        seconds = 30
+
+        [backends.circuit_breaker]
+        failure_rate_threshold = 0.5
+        minimum_calls = 10
+        wait_duration_seconds = 60
+        permitted_calls_in_half_open = 3
+
+        [backends.rate_limit]
+        requests = 100
+        period_seconds = 1
+
+        [backends.retry]
+        max_retries = 3
+        initial_backoff_ms = 100
+        max_backoff_ms = 5000
+        budget_percent = 20.0
+
+        [backends.cache]
+        tool_ttl_seconds = 30
+        max_entries = 500
+
+        # Failover backend -- takes over when primary fails
+        [[backends]]
+        name = "api-fallback"
+        transport = "http"
+        url = "http://api-fallback:8080"
+        failover_for = "api"
+        priority = 1
+
+        [backends.timeout]
+        seconds = 60
+        "#,
+    )?;
+
+    println!("Resilience config:");
+    for backend in &config.backends {
+        println!("  Backend: {}", backend.name);
+        if backend.timeout.is_some() {
+            println!("    - timeout");
+        }
+        if backend.circuit_breaker.is_some() {
+            println!("    - circuit breaker");
+        }
+        if backend.rate_limit.is_some() {
+            println!("    - rate limit");
+        }
+        if backend.retry.is_some() {
+            println!("    - retry");
+        }
+        if backend.cache.is_some() {
+            println!("    - caching");
+        }
+        if backend.failover_for.is_some() {
+            println!(
+                "    - failover for: {}",
+                backend.failover_for.as_deref().unwrap()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/scoped_tokens.rs
+++ b/examples/scoped_tokens.rs
@@ -1,0 +1,72 @@
+//! Per-token tool scoping -- restrict tool access per bearer token.
+//!
+//! Demonstrates configuring bearer tokens where each token has its own
+//! allow/deny list for tools. Bridges the gap between all-or-nothing
+//! bearer auth and full JWT/RBAC.
+//!
+//! Run with: `cargo run --example scoped_tokens`
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = mcp_proxy::ProxyConfig::parse(
+        r#"
+        [proxy]
+        name = "scoped-proxy"
+        [proxy.listen]
+
+        [[backends]]
+        name = "files"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "db"
+        transport = "stdio"
+        command = "echo"
+
+        [auth]
+        type = "bearer"
+        # Admin token -- unrestricted access to all tools
+        tokens = ["admin-token-xxx"]
+
+        # Frontend token -- read-only file access
+        [[auth.scoped_tokens]]
+        token = "frontend-token-xxx"
+        allow_tools = ["files/read_file", "files/list_directory"]
+
+        # Analytics token -- database read access, no file access
+        [[auth.scoped_tokens]]
+        token = "analytics-token-xxx"
+        allow_tools = ["db/query"]
+
+        # Operator token -- everything except destructive ops
+        [[auth.scoped_tokens]]
+        token = "operator-token-xxx"
+        deny_tools = ["db/drop_table", "files/delete_file"]
+        "#,
+    )?;
+
+    println!("Scoped token config parsed:");
+    match &config.auth {
+        Some(mcp_proxy::config::AuthConfig::Bearer {
+            tokens,
+            scoped_tokens,
+        }) => {
+            println!("  Unrestricted tokens: {}", tokens.len());
+            println!("  Scoped tokens: {}", scoped_tokens.len());
+            for st in scoped_tokens {
+                let scope = if !st.allow_tools.is_empty() {
+                    format!("allow: {:?}", st.allow_tools)
+                } else if !st.deny_tools.is_empty() {
+                    format!("deny: {:?}", st.deny_tools)
+                } else {
+                    "unrestricted".to_string()
+                };
+                println!("    - {}", scope);
+            }
+        }
+        _ => println!("  (unexpected auth type)"),
+    }
+
+    Ok(())
+}

--- a/examples/search_mode.rs
+++ b/examples/search_mode.rs
@@ -1,0 +1,52 @@
+//! Search mode -- expose meta-tools instead of individual tools.
+//!
+//! When aggregating many backends with hundreds of tools, listing them all
+//! overwhelms LLM context. Search mode replaces N tool registrations with
+//! meta-tools that agents use to discover and invoke tools on demand.
+//!
+//! Run with: `cargo run --example search_mode --features discovery`
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = mcp_proxy::ProxyConfig::parse(
+        r#"
+        [proxy]
+        name = "search-proxy"
+        # Search mode: hide individual tools, expose meta-tools only
+        tool_exposure = "search"
+        # tool_discovery = true   # implied by search mode
+        [proxy.listen]
+
+        # Imagine 10+ backends with dozens of tools each...
+        [[backends]]
+        name = "github"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "filesystem"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "database"
+        transport = "stdio"
+        command = "echo"
+        "#,
+    )?;
+
+    println!("Search mode config:");
+    println!("  Tool exposure: {:?}", config.proxy.tool_exposure);
+    println!("  Backends: {}", config.backends.len());
+    println!();
+    println!("In search mode, ListTools returns only:");
+    println!("  - proxy/search_tools    (BM25 full-text search)");
+    println!("  - proxy/similar_tools   (find related tools)");
+    println!("  - proxy/tool_categories (browse by backend)");
+    println!("  - proxy/call_tool       (invoke any tool by name)");
+    println!();
+    println!("Agents discover tools via search, then invoke via call_tool.");
+    println!("Backend tools still work -- they're just hidden from listing.");
+
+    Ok(())
+}

--- a/examples/websocket-backend.toml
+++ b/examples/websocket-backend.toml
@@ -1,0 +1,31 @@
+# WebSocket backend example
+# Connect to a WebSocket-based MCP server alongside stdio and HTTP backends.
+
+[proxy]
+name = "ws-proxy"
+[proxy.listen]
+host = "0.0.0.0"
+port = 8080
+
+# Local stdio backend
+[[backends]]
+name = "files"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+
+# Remote HTTP backend
+[[backends]]
+name = "api"
+transport = "http"
+url = "http://api-server:8080"
+
+# WebSocket backend (ws:// or wss://)
+[[backends]]
+name = "realtime"
+transport = "websocket"
+url = "wss://mcp.example.com/ws"
+bearer_token = "${WS_TOKEN}"
+
+[backends.timeout]
+seconds = 60


### PR DESCRIPTION
## Summary

Adds 4 Rust examples and 3 config scenario examples covering new features.

### Rust examples (library usage)
- `oauth_setup.rs` -- OAuth 2.1 with auto-discovery and RBAC
- `scoped_tokens.rs` -- per-token tool allow/deny lists
- `search_mode.rs` -- meta-tools for large deployments
- `resilience.rs` -- full resilience stack with failover

### Config examples (CLI usage)
- `websocket-backend.toml` -- mixed stdio/http/websocket transports
- `multi-instance-redis.toml` -- shared Redis cache, admin auth, JSON logs
- `canary-rollout.toml` -- canary routing + traffic mirroring + audit

All Rust examples compile and pass clippy.

## Test plan

- [x] `cargo build --examples --all-features` passes
- [x] clippy, fmt clean