### PR TITLE
test: add unit tests for admin_tools, coalesce, and reload

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -335,7 +335,7 @@ async fn handle_cache_clear(
 
 /// Create an `AdminState` directly for testing.
 #[cfg(test)]
-fn test_admin_state(
+pub(crate) fn test_admin_state(
     proxy_name: &str,
     proxy_version: &str,
     backend_count: usize,

--- a/src/admin_tools.rs
+++ b/src/admin_tools.rs
@@ -309,3 +309,202 @@ struct CallToolInput {
     /// Arguments to pass to the tool
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use tower::Service;
+    use tower_mcp::client::ChannelTransport;
+    use tower_mcp::protocol::{
+        CallToolParams, ListToolsParams, McpRequest, McpResponse, RequestId,
+    };
+    use tower_mcp::proxy::McpProxy;
+    use tower_mcp::router::{Extensions, RouterRequest};
+    use tower_mcp::{CallToolResult, McpRouter, SessionHandle, ToolBuilder};
+
+    use super::*;
+
+    fn make_session_handle() -> SessionHandle {
+        let svc = tower::util::BoxCloneService::new(tower::service_fn(
+            |_req: tower_mcp::RouterRequest| async {
+                Ok::<_, std::convert::Infallible>(tower_mcp::RouterResponse {
+                    id: RequestId::Number(1),
+                    inner: Ok(McpResponse::Pong(Default::default())),
+                })
+            },
+        ));
+        let (_, handle) =
+            tower_mcp::transport::http::HttpTransport::from_service(svc).into_router_with_handle();
+        handle
+    }
+
+    fn make_admin_state() -> AdminState {
+        crate::admin::test_admin_state("test-proxy", "0.1.0", 0, vec![])
+    }
+
+    async fn make_test_proxy() -> McpProxy {
+        let router = McpRouter::new().server_info("test", "1.0.0").tool(
+            ToolBuilder::new("ping")
+                .description("Ping")
+                .handler(|_: tower_mcp::NoParams| async move { Ok(CallToolResult::text("pong")) })
+                .build(),
+        );
+
+        McpProxy::builder("test-proxy", "1.0.0")
+            .backend("test", ChannelTransport::new(router))
+            .await
+            .build_strict()
+            .await
+            .unwrap()
+    }
+
+    async fn list_tools(proxy: &mut McpProxy) -> Vec<String> {
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ListTools(ListToolsParams {
+                cursor: None,
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let resp = proxy.call(req).await.expect("infallible");
+        match resp.inner.unwrap() {
+            McpResponse::ListTools(result) => result.tools.into_iter().map(|t| t.name).collect(),
+            other => panic!("expected ListTools, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_admin_router_has_expected_tools() {
+        let proxy = make_test_proxy().await;
+        let state = AdminToolState {
+            admin_state: make_admin_state(),
+            session_handle: make_session_handle(),
+            config_snapshot: Arc::new("# empty config".to_string()),
+            proxy: proxy.clone(),
+        };
+
+        let router = build_admin_router(state, None, false, vec![]);
+        let transport = ChannelTransport::new(router);
+
+        let mut test_proxy = McpProxy::builder("verify", "1.0.0")
+            .backend("admin", transport)
+            .await
+            .build_strict()
+            .await
+            .unwrap();
+
+        let tools = list_tools(&mut test_proxy).await;
+        assert!(tools.contains(&"admin_list_backends".to_string()));
+        assert!(tools.contains(&"admin_health_check".to_string()));
+        assert!(tools.contains(&"admin_session_count".to_string()));
+        assert!(tools.contains(&"admin_add_backend".to_string()));
+        assert!(tools.contains(&"admin_config".to_string()));
+        // call_tool should NOT be present when search_mode is false
+        assert!(!tools.contains(&"admin_call_tool".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_search_mode_adds_call_tool() {
+        let proxy = make_test_proxy().await;
+        let state = AdminToolState {
+            admin_state: make_admin_state(),
+            session_handle: make_session_handle(),
+            config_snapshot: Arc::new(String::new()),
+            proxy: proxy.clone(),
+        };
+
+        let router = build_admin_router(state, None, true, vec![]);
+        let transport = ChannelTransport::new(router);
+
+        let mut test_proxy = McpProxy::builder("verify", "1.0.0")
+            .backend("admin", transport)
+            .await
+            .build_strict()
+            .await
+            .unwrap();
+
+        let tools = list_tools(&mut test_proxy).await;
+        assert!(
+            tools.contains(&"admin_call_tool".to_string()),
+            "search mode should add call_tool, got: {tools:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_discovery_tools_included() {
+        let proxy = make_test_proxy().await;
+        let state = AdminToolState {
+            admin_state: make_admin_state(),
+            session_handle: make_session_handle(),
+            config_snapshot: Arc::new(String::new()),
+            proxy: proxy.clone(),
+        };
+
+        let extra_tool = ToolBuilder::new("search_tools")
+            .description("Search for tools")
+            .handler(
+                |_: tower_mcp::NoParams| async move { Ok(CallToolResult::text("search results")) },
+            )
+            .build();
+
+        let router = build_admin_router(state, Some(vec![extra_tool]), false, vec![]);
+        let transport = ChannelTransport::new(router);
+
+        let mut test_proxy = McpProxy::builder("verify", "1.0.0")
+            .backend("admin", transport)
+            .await
+            .build_strict()
+            .await
+            .unwrap();
+
+        let tools = list_tools(&mut test_proxy).await;
+        assert!(
+            tools.contains(&"admin_search_tools".to_string()),
+            "discovery tool should be included, got: {tools:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_tool_returns_snapshot() {
+        let config_text = "[proxy]\nname = \"test\"\n".to_string();
+        let proxy = make_test_proxy().await;
+        let state = AdminToolState {
+            admin_state: make_admin_state(),
+            session_handle: make_session_handle(),
+            config_snapshot: Arc::new(config_text.clone()),
+            proxy: proxy.clone(),
+        };
+
+        let router = build_admin_router(state, None, false, vec![]);
+        let transport = ChannelTransport::new(router);
+
+        let mut test_proxy = McpProxy::builder("verify", "1.0.0")
+            .backend("admin", transport)
+            .await
+            .build_strict()
+            .await
+            .unwrap();
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                name: "admin_config".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let resp = test_proxy.call(req).await.expect("infallible");
+        match resp.inner.unwrap() {
+            McpResponse::CallTool(result) => {
+                let text = result.all_text();
+                assert!(
+                    text.contains("[proxy]"),
+                    "config tool should return the config snapshot, got: {text}"
+                );
+            }
+            other => panic!("expected CallTool, got: {other:?}"),
+        }
+    }
+}

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -193,4 +193,200 @@ mod tests {
             }));
         assert_ne!(key1, key2, "different args should have different keys");
     }
+
+    #[tokio::test]
+    async fn test_coalesce_key_same_arguments_produce_same_key() {
+        let key1 =
+            super::coalesce_key(&McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "tool".to_string(),
+                arguments: serde_json::json!({"a": 1}),
+                meta: None,
+                task: None,
+            }));
+        let key2 =
+            super::coalesce_key(&McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "tool".to_string(),
+                arguments: serde_json::json!({"a": 1}),
+                meta: None,
+                task: None,
+            }));
+        assert_eq!(key1, key2, "same tool+args should have the same key");
+    }
+
+    #[tokio::test]
+    async fn test_coalesce_key_read_resource() {
+        let key = super::coalesce_key(&McpRequest::ReadResource(
+            tower_mcp::protocol::ReadResourceParams {
+                uri: "file:///tmp/test.txt".to_string(),
+                meta: None,
+            },
+        ));
+        assert_eq!(key, Some("res:file:///tmp/test.txt".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_coalesce_key_non_coalesceable_returns_none() {
+        let key = super::coalesce_key(&McpRequest::ListTools(Default::default()));
+        assert!(key.is_none(), "ListTools should not be coalesceable");
+
+        let key = super::coalesce_key(&McpRequest::ListResources(Default::default()));
+        assert!(key.is_none(), "ListResources should not be coalesceable");
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_identical_requests_coalesced() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tower::Service;
+
+        // A mock that counts how many times it's actually called
+        #[derive(Clone)]
+        struct CountingService {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl Service<tower_mcp::router::RouterRequest> for CountingService {
+            type Response = tower_mcp::router::RouterResponse;
+            type Error = std::convert::Infallible;
+            type Future = std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<
+                                tower_mcp::router::RouterResponse,
+                                std::convert::Infallible,
+                            >,
+                        > + Send,
+                >,
+            >;
+
+            fn poll_ready(
+                &mut self,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: tower_mcp::router::RouterRequest) -> Self::Future {
+                let count = self.call_count.clone();
+                let id = req.id.clone();
+                Box::pin(async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    // Small delay to ensure concurrent requests overlap
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    Ok(tower_mcp::router::RouterResponse {
+                        id,
+                        inner: Ok(McpResponse::CallTool(
+                            tower_mcp::protocol::CallToolResult::text("result"),
+                        )),
+                    })
+                })
+            }
+        }
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let svc = CountingService {
+            call_count: call_count.clone(),
+        };
+        let coalesce = CoalesceService::new(svc);
+
+        let make_request = || {
+            let mut c = coalesce.clone();
+            let req = tower_mcp::router::RouterRequest {
+                id: tower_mcp::protocol::RequestId::Number(1),
+                inner: McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                    name: "tool".to_string(),
+                    arguments: serde_json::json!({"x": 42}),
+                    meta: None,
+                    task: None,
+                }),
+                extensions: tower_mcp::router::Extensions::new(),
+            };
+            async move { c.call(req).await }
+        };
+
+        // Fire 3 identical requests concurrently
+        let (r1, r2, r3) = tokio::join!(make_request(), make_request(), make_request());
+
+        // All should succeed
+        assert!(r1.is_ok());
+        assert!(r2.is_ok());
+        assert!(r3.is_ok());
+
+        // The backend should be called at most twice (the first caller registers,
+        // some others may arrive before the lock is acquired). The key invariant
+        // is that it's called fewer times than the number of requests.
+        let count = call_count.load(Ordering::SeqCst);
+        assert!(
+            count < 3,
+            "expected fewer than 3 backend calls due to coalescing, got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_different_requests_not_coalesced() {
+        let mock = MockService::with_tools(&["tool"]);
+        let coalesce = CoalesceService::new(mock);
+
+        // Two requests with different arguments
+        let mut c1 = coalesce.clone();
+        let req1 = tower_mcp::router::RouterRequest {
+            id: tower_mcp::protocol::RequestId::Number(1),
+            inner: McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "tool".to_string(),
+                arguments: serde_json::json!({"x": 1}),
+                meta: None,
+                task: None,
+            }),
+            extensions: tower_mcp::router::Extensions::new(),
+        };
+
+        let mut c2 = coalesce.clone();
+        let req2 = tower_mcp::router::RouterRequest {
+            id: tower_mcp::protocol::RequestId::Number(2),
+            inner: McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "tool".to_string(),
+                arguments: serde_json::json!({"x": 2}),
+                meta: None,
+                task: None,
+            }),
+            extensions: tower_mcp::router::Extensions::new(),
+        };
+
+        let (r1, r2) = tokio::join!(
+            tower::Service::call(&mut c1, req1),
+            tower::Service::call(&mut c2, req2)
+        );
+
+        // Both should succeed independently
+        assert!(r1.is_ok());
+        assert!(r2.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_coalesce_with_error_response() {
+        use crate::test_util::ErrorMockService;
+
+        let mock = ErrorMockService;
+        let mut svc = CoalesceService::new(mock);
+
+        let resp = call_service(
+            &mut svc,
+            McpRequest::CallTool(tower_mcp::protocol::CallToolParams {
+                name: "failing_tool".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        // The error response should pass through correctly
+        assert!(
+            resp.inner.is_err(),
+            "error response should propagate through coalesce"
+        );
+        let err = resp.inner.unwrap_err();
+        assert_eq!(err.code, -32603);
+        assert_eq!(err.message, "internal error");
+    }
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -445,3 +445,141 @@ fn build_backend_layer(backend: &BackendConfig) -> BackendMiddlewareLayer {
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn http_backend(name: &str, url: &str) -> BackendConfig {
+        // Parse from TOML to get all default values automatically
+        let toml = format!(
+            r#"
+            name = "{name}"
+            transport = "http"
+            url = "{url}"
+            "#,
+        );
+        toml::from_str(&toml).unwrap()
+    }
+
+    #[test]
+    fn test_config_fingerprint_stable() {
+        let backend = http_backend("api", "http://localhost:8080");
+        let fp1 = config_fingerprint(&backend);
+        let fp2 = config_fingerprint(&backend);
+        assert_eq!(fp1, fp2, "fingerprint should be stable across calls");
+    }
+
+    #[test]
+    fn test_config_fingerprint_differs_on_url_change() {
+        let b1 = http_backend("api", "http://localhost:8080");
+        let b2 = http_backend("api", "http://localhost:9090");
+        assert_ne!(
+            config_fingerprint(&b1),
+            config_fingerprint(&b2),
+            "different URLs should produce different fingerprints"
+        );
+    }
+
+    #[test]
+    fn test_config_fingerprint_differs_on_name_change() {
+        let b1 = http_backend("api", "http://localhost:8080");
+        let b2 = http_backend("api2", "http://localhost:8080");
+        assert_ne!(
+            config_fingerprint(&b1),
+            config_fingerprint(&b2),
+            "different names should produce different fingerprints"
+        );
+    }
+
+    #[test]
+    fn test_config_fingerprint_differs_on_transport_change() {
+        let b1 = http_backend("api", "http://localhost:8080");
+        let b2: BackendConfig = toml::from_str(
+            r#"
+            name = "api"
+            transport = "stdio"
+            command = "echo"
+            "#,
+        )
+        .unwrap();
+        assert_ne!(
+            config_fingerprint(&b1),
+            config_fingerprint(&b2),
+            "different transports should produce different fingerprints"
+        );
+    }
+
+    #[test]
+    fn test_config_fingerprint_differs_with_timeout() {
+        let b1 = http_backend("api", "http://localhost:8080");
+        let b2: BackendConfig = toml::from_str(
+            r#"
+            name = "api"
+            transport = "http"
+            url = "http://localhost:8080"
+            [timeout]
+            seconds = 30
+            "#,
+        )
+        .unwrap();
+        assert_ne!(
+            config_fingerprint(&b1),
+            config_fingerprint(&b2),
+            "adding a timeout should change the fingerprint"
+        );
+    }
+
+    #[test]
+    fn test_fingerprint_map_detects_additions_and_removals() {
+        let backends_v1 = [
+            http_backend("api", "http://api:8080"),
+            http_backend("db", "http://db:5432"),
+        ];
+        let backends_v2 = [
+            http_backend("api", "http://api:8080"),
+            http_backend("cache", "http://cache:6379"),
+        ];
+
+        let fp_v1: HashMap<String, String> = backends_v1
+            .iter()
+            .map(|b| (b.name.clone(), config_fingerprint(b)))
+            .collect();
+        let fp_v2: HashMap<String, String> = backends_v2
+            .iter()
+            .map(|b| (b.name.clone(), config_fingerprint(b)))
+            .collect();
+
+        let old_names: HashSet<&String> = fp_v1.keys().collect();
+        let new_names: HashSet<&String> = fp_v2.keys().collect();
+
+        let added: HashSet<_> = new_names.difference(&old_names).collect();
+        let removed: HashSet<_> = old_names.difference(&new_names).collect();
+
+        assert_eq!(added.len(), 1, "one backend should be added");
+        assert!(added.contains(&&"cache".to_string()));
+        assert_eq!(removed.len(), 1, "one backend should be removed");
+        assert!(removed.contains(&&"db".to_string()));
+    }
+
+    #[test]
+    fn test_fingerprint_map_detects_modifications() {
+        let b_old = http_backend("api", "http://api:8080");
+        let b_new = http_backend("api", "http://api:9090");
+
+        let fp_old = config_fingerprint(&b_old);
+        let fp_new = config_fingerprint(&b_new);
+
+        assert_ne!(
+            fp_old, fp_new,
+            "modified backend should have a different fingerprint"
+        );
+    }
+
+    // NOTE: Testing the full watch_loop is impractical in unit tests because
+    // it requires real filesystem events and a running tokio runtime with
+    // file watchers. The core logic (fingerprint computation and set
+    // difference for add/remove/replace) is tested above via the extracted
+    // config_fingerprint function and HashMap operations that mirror the
+    // watch_loop implementation.
+}


### PR DESCRIPTION
## Summary

Adds 17 unit tests to modules with zero or low coverage.

- **admin_tools** (4 tests): router tool listing, search mode call_tool, discovery tools inclusion, config snapshot
- **coalesce** (6 tests): key generation, concurrent coalescing verification with CountingService, different requests not coalesced, error propagation
- **reload** (7 tests): config fingerprint stability, change detection for URL/name/transport/middleware, set-difference logic for additions/removals/modifications

## Test plan

- [x] All 258 lib tests pass
- [x] clippy, fmt clean