### PR TITLE
fix: require admin_token when auth is jwt/oauth (admin plane was unauthenticated)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -310,6 +310,9 @@ url = "http://mcp-server:8080"
 
 # [security]
 # max_argument_size = 1048576    # 1MB limit on tool call arguments
+# admin_token = "${ADMIN_TOKEN}" # Bearer token for the /admin API. REQUIRED when
+#                                # auth.type is jwt/oauth (those auth types have no
+#                                # token fallback for admin); optional otherwise.
 
 # =============================================================================
 # Observability

--- a/examples/compliance.toml
+++ b/examples/compliance.toml
@@ -122,6 +122,9 @@ max_entries = 2000
 
 [security]
 max_argument_size = 65536  # 64KB -- strict limit
+# Required when auth.type is jwt/oauth: the admin API has no token fallback for
+# these auth types, so an explicit admin token is mandatory.
+admin_token = "${ADMIN_TOKEN}"
 
 [performance]
 coalesce_requests = true

--- a/examples/enterprise-hub.toml
+++ b/examples/enterprise-hub.toml
@@ -132,6 +132,9 @@ coalesce_requests = true
 
 [security]
 max_argument_size = 1048576  # 1MB
+# Required when auth.type is jwt/oauth: the admin API has no token fallback for
+# these auth types, so an explicit admin token is mandatory.
+admin_token = "${ADMIN_TOKEN}"
 
 [observability]
 audit = true

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -57,8 +57,13 @@
 //! resolves the admin token using a fallback chain:
 //!
 //! 1. `security.admin_token` -- explicit bearer token for admin access.
-//! 2. Proxy's inbound auth config -- reuses the same auth as MCP endpoints.
+//! 2. Proxy's bearer auth tokens -- reused when `auth.type = "bearer"`.
 //! 3. If neither is set, the admin API is open (suitable for local/dev use).
+//!
+//! When `auth.type` is `jwt` or `oauth` there is no static-token fallback
+//! (step 2 only applies to bearer auth), so `security.admin_token` is
+//! **required** -- config validation rejects its absence to avoid leaving the
+//! admin plane unauthenticated.
 //!
 //! The token supports `${ENV_VAR}` syntax for environment variable expansion.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -865,8 +865,11 @@ pub struct SecurityConfig {
     pub max_argument_size: Option<usize>,
     /// Bearer token for admin API access. If set, all admin endpoints require
     /// `Authorization: Bearer <token>`. If not set, falls back to the proxy's
-    /// inbound auth config. If neither is set, admin API is open.
-    /// Supports `${ENV_VAR}` syntax.
+    /// bearer auth tokens (bearer auth only). When `auth.type` is `jwt` or
+    /// `oauth` this token is **required** -- those auth types have no static
+    /// fallback for the admin plane, so config validation rejects a missing
+    /// `admin_token`. With no auth configured at all, the admin API is open
+    /// (suitable for local/dev use). Supports `${ENV_VAR}` syntax.
     pub admin_token: Option<String>,
 }
 
@@ -1499,6 +1502,23 @@ impl ProxyConfig {
             anyhow::bail!("OAuth introspection requires both 'client_id' and 'client_secret'");
         }
 
+        // Admin API protection: JWT/OAuth auth has no static-token fallback for
+        // the admin plane (resolve_admin_tokens only derives tokens from bearer
+        // auth). Without an explicit admin_token the admin endpoints -- which can
+        // add backends, rewrite the running config, and terminate sessions --
+        // would be left unauthenticated. Require admin_token to be set in that case.
+        if matches!(
+            &self.auth,
+            Some(AuthConfig::Jwt { .. }) | Some(AuthConfig::OAuth { .. })
+        ) && self.security.admin_token.is_none()
+        {
+            anyhow::bail!(
+                "security.admin_token is required when auth.type is 'jwt' or 'oauth': \
+                 the admin API has no token fallback for these auth types and would be \
+                 left unauthenticated. Set security.admin_token (supports ${{ENV_VAR}})."
+            );
+        }
+
         // Check for duplicate backend names
         let mut seen_names = HashSet::new();
         for backend in &self.backends {
@@ -2087,6 +2107,9 @@ mod tests {
         [auth.role_mapping]
         claim = "scope"
         mapping = { "mcp:read" = "reader", "mcp:admin" = "admin" }
+
+        [security]
+        admin_token = "admin-secret"
         "#;
 
         let config = ProxyConfig::parse(toml).unwrap();
@@ -2755,6 +2778,84 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_jwt_requires_admin_token() {
+        // JWT auth without security.admin_token must be rejected: the admin
+        // plane has no token fallback for JWT/OAuth and would be left open.
+        let toml = r#"
+        [proxy]
+        name = "jwt-gw"
+        [proxy.listen]
+
+        [[backends]]
+        name = "echo"
+        transport = "stdio"
+        command = "echo"
+
+        [auth]
+        type = "jwt"
+        issuer = "https://auth.example.com"
+        audience = "mcp-proxy"
+        jwks_uri = "https://auth.example.com/.well-known/jwks.json"
+        "#;
+        let err = ProxyConfig::parse(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("admin_token"),
+            "expected admin_token error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_jwt_with_admin_token_ok() {
+        // Same config with an explicit admin_token validates successfully.
+        let toml = r#"
+        [proxy]
+        name = "jwt-gw"
+        [proxy.listen]
+
+        [[backends]]
+        name = "echo"
+        transport = "stdio"
+        command = "echo"
+
+        [auth]
+        type = "jwt"
+        issuer = "https://auth.example.com"
+        audience = "mcp-proxy"
+        jwks_uri = "https://auth.example.com/.well-known/jwks.json"
+
+        [security]
+        admin_token = "admin-secret"
+        "#;
+        assert!(ProxyConfig::parse(toml).is_ok());
+    }
+
+    #[test]
+    fn test_validate_oauth_requires_admin_token() {
+        // OAuth (JWT-validation strategy, so credentials aren't required) without
+        // admin_token must also be rejected.
+        let toml = r#"
+        [proxy]
+        name = "oauth-gw"
+        [proxy.listen]
+
+        [[backends]]
+        name = "echo"
+        transport = "stdio"
+        command = "echo"
+
+        [auth]
+        type = "oauth"
+        issuer = "https://auth.example.com"
+        audience = "mcp-proxy"
+        "#;
+        let err = ProxyConfig::parse(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("admin_token"),
+            "expected admin_token error, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_parse_global_rate_limit() {
         let toml = r#"
         [proxy]
@@ -3350,6 +3451,9 @@ mod tests {
         type = "oauth"
         issuer = "https://accounts.google.com"
         audience = "mcp-proxy"
+
+        [security]
+        admin_token = "admin-secret"
         "#;
 
         let config = ProxyConfig::parse(toml).unwrap();
@@ -3387,6 +3491,9 @@ mod tests {
         client_id = "my-client"
         client_secret = "my-secret"
         token_validation = "introspection"
+
+        [security]
+        admin_token = "admin-secret"
         "#;
 
         let config = ProxyConfig::parse(toml).unwrap();
@@ -3453,6 +3560,9 @@ mod tests {
         client_secret = "my-secret"
         token_validation = "both"
         required_scopes = ["read", "write"]
+
+        [security]
+        admin_token = "admin-secret"
         "#;
 
         let config = ProxyConfig::parse(toml).unwrap();
@@ -3582,6 +3692,9 @@ mod tests {
         client_id = "my-client"
         client_secret = "${TOTALLY_UNSET_OAUTH_SECRET}"
         token_validation = "introspection"
+
+        [security]
+        admin_token = "admin-secret"
         "#;
 
         let config = ProxyConfig::parse(toml).unwrap();

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -378,7 +378,7 @@ pub fn build_discovery_tools(index: SharedDiscoveryIndex) -> Vec<tower_mcp::Tool
                 let registry = idx.read().await;
                 let categories = registry.list_categories();
                 let mut cats: Vec<CategorySummary> = categories.into_values().collect();
-                cats.sort_by(|a, b| b.tool_count.cmp(&a.tool_count));
+                cats.sort_by_key(|b| std::cmp::Reverse(b.tool_count));
                 let result = CategoriesResult {
                     total_categories: cats.len(),
                     categories: cats,

--- a/src/skills/configure_auth.md
+++ b/src/skills/configure_auth.md
@@ -34,6 +34,11 @@ type = "jwt"
 issuer = "https://auth.example.com"
 audience = "mcp-proxy"
 jwks_uri = "https://auth.example.com/.well-known/jwks.json"
+
+# Required with jwt/oauth: the admin API has no token fallback for these auth
+# types, so an explicit admin token is mandatory (config validation enforces it).
+[security]
+admin_token = "${ADMIN_TOKEN}"
 ```
 
 With RBAC roles:
@@ -59,6 +64,10 @@ Auto-discovers JWKS and introspection endpoints from the issuer URL.
 type = "oauth"
 issuer = "https://accounts.google.com"
 audience = "mcp-proxy"
+
+# Required with jwt/oauth (see note above).
+[security]
+admin_token = "${ADMIN_TOKEN}"
 ```
 
 With token introspection (for opaque tokens):


### PR DESCRIPTION
## Problem

When `auth.type` is `jwt` or `oauth` and no explicit `security.admin_token` is set, the **entire admin API is unauthenticated**.

Mechanism:
- `proxy.rs` applies the inbound JWT/OAuth `AuthLayer` to the MCP router, then mounts the admin router with `router.nest("/admin", ...)` *afterward*. In Axum 0.8 a `.layer()` only wraps routes registered before it -- nested routes added later do **not** inherit it.
- Admin's only protection is its own internal layer in `admin_router`, built from `resolve_admin_tokens`, which derives tokens **only from bearer auth** (`_ => vec![]` for jwt/oauth).
- Net effect: `POST /admin/backends/add`, `PUT /admin/config` (rewrites running config + hot-reloads), `DELETE /admin/sessions/{id}`, etc. reachable with no credential.

Found during an auth-gateway readiness audit. This is the top blocker for using mcp-proxy as an auth gateway.

## Fix

Fail closed: config validation now **rejects** `jwt`/`oauth` auth that lacks an explicit `security.admin_token`. JWT/OAuth have no static-token fallback for the admin plane, so an explicit admin credential is mandatory. This also surfaces the misconfig at `--check` time.

- `src/config.rs` -- validation guard + doc update on `SecurityConfig::admin_token`
- `src/admin.rs` -- module-doc auth section corrected (fallback applies to bearer only)
- `examples/compliance.toml`, `examples/enterprise-hub.toml`, `config.example.toml`, `src/skills/configure_auth.md` -- model the required `admin_token` pattern
- Tests: negative (jwt + oauth without admin_token -> rejected) and positive (with admin_token -> ok)

Incidental: fixes a pre-existing `unnecessary_sort_by` clippy lint in `discovery.rs` flagged by the current toolchain (unrelated; included to keep the clippy gate green).

## Verification

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- `cargo test --all-features` -- 282 lib tests + integration/e2e green
- `--check` on `examples/compliance.toml` validates with the admin_token present

## Follow-ups (separate issues)

Remaining audit findings (P2) to be filed: `required_scopes` silently ignored, RBAC default-allow on unmapped scope, introspection audience fail-open when `aud` absent, missing negative auth E2E tests.