### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-06-10
+
+### Bug Fixes
+
+- Require admin_token when auth is jwt or oauth ([#174](https://github.com/joshrotenberg/mcp-proxy/pull/174))
+- Patch TLS cert-validation advisories + compatible dep bumps ([#173](https://github.com/joshrotenberg/mcp-proxy/pull/173))
+- Reject introspection tokens with missing aud when audience configured (closes #177) ([#180](https://github.com/joshrotenberg/mcp-proxy/pull/180))
+- Enforce required_scopes in oauth auth (closes #175) ([#182](https://github.com/joshrotenberg/mcp-proxy/pull/182))
+
+### Features
+
+- Add rbac default_deny for unmapped scopes (closes #176) ([#181](https://github.com/joshrotenberg/mcp-proxy/pull/181))
+
+### Miscellaneous Tasks
+
+- Upgrade tower-mcp 0.9.2 -> 0.12.0 ([#184](https://github.com/joshrotenberg/mcp-proxy/pull/184))
+- Upgrade opentelemetry stack 0.29 -> 0.32 ([#185](https://github.com/joshrotenberg/mcp-proxy/pull/185))
+- Bump remaining dependencies to latest ([#186](https://github.com/joshrotenberg/mcp-proxy/pull/186))
+
+### Testing
+
+- Add http-level negative auth tests (closes #178) ([#183](https://github.com/joshrotenberg/mcp-proxy/pull/183))
+
+
+
 ## [0.3.1] - 2026-03-18
 
 ### Testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,7 +1810,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Standalone MCP proxy -- config-driven reverse proxy with auth, rate limiting, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `mcp-proxy` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RoleMappingConfig.default_deny in /tmp/.tmpR2Hw5y/mcp-proxy/src/config.rs:802
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0] - 2026-06-10

### Bug Fixes

- Require admin_token when auth is jwt or oauth ([#174](https://github.com/joshrotenberg/mcp-proxy/pull/174))
- Patch TLS cert-validation advisories + compatible dep bumps ([#173](https://github.com/joshrotenberg/mcp-proxy/pull/173))
- Reject introspection tokens with missing aud when audience configured (closes #177) ([#180](https://github.com/joshrotenberg/mcp-proxy/pull/180))
- Enforce required_scopes in oauth auth (closes #175) ([#182](https://github.com/joshrotenberg/mcp-proxy/pull/182))

### Features

- Add rbac default_deny for unmapped scopes (closes #176) ([#181](https://github.com/joshrotenberg/mcp-proxy/pull/181))

### Miscellaneous Tasks

- Upgrade tower-mcp 0.9.2 -> 0.12.0 ([#184](https://github.com/joshrotenberg/mcp-proxy/pull/184))
- Upgrade opentelemetry stack 0.29 -> 0.32 ([#185](https://github.com/joshrotenberg/mcp-proxy/pull/185))
- Bump remaining dependencies to latest ([#186](https://github.com/joshrotenberg/mcp-proxy/pull/186))

### Testing

- Add http-level negative auth tests (closes #178) ([#183](https://github.com/joshrotenberg/mcp-proxy/pull/183))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).