### PR TITLE
test: add http-level negative auth tests (closes #178)

### DIFF
--- a/tests/http_e2e.rs
+++ b/tests/http_e2e.rs
@@ -158,6 +158,116 @@ async fn spawn_proxy_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     (addr, handle)
 }
 
+/// Build an McpProxy like [`spawn_proxy_server`], but with bearer auth enforced
+/// on the MCP endpoint and an admin token protecting `/admin/*`.
+///
+/// The single `token` is used for *both* the MCP bearer auth and the admin
+/// token, mirroring how `apply_auth` (src/proxy.rs) wraps the MCP transport
+/// router with `AuthLayer::new(StaticBearerValidator::new(...))` and how
+/// `admin::admin_router` builds its own auth layer from
+/// `resolve_admin_tokens` (src/admin.rs). The two layers are independent: the
+/// MCP layer is applied before the `/admin` nest, so it does not cover admin
+/// routes, and the admin router carries its own layer derived from
+/// `security.admin_token`.
+async fn spawn_proxy_server_with_bearer(token: &str) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let proxy = McpProxy::builder("test-proxy", "1.0.0")
+        .separator("/")
+        .backend("math", ChannelTransport::new(math_router()))
+        .await
+        .backend("text", ChannelTransport::new(text_router()))
+        .await
+        .build_strict()
+        .await
+        .expect("proxy should build");
+
+    let proxy_for_admin = proxy.clone();
+    let proxy_for_mgmt = proxy.clone();
+
+    let service: BoxCloneService<RouterRequest, RouterResponse, Infallible> =
+        BoxCloneService::new(proxy);
+
+    let (router, session_handle) =
+        tower_mcp::transport::http::HttpTransport::from_service(service).into_router_with_handle();
+
+    // Enforce bearer auth on the MCP endpoint, mirroring `apply_auth`. Applied
+    // before the `/admin` nest so it covers only the MCP routes.
+    let validator = tower_mcp::auth::StaticBearerValidator::new([token.to_string()]);
+    let router = router.layer(tower_mcp::auth::AuthLayer::new(validator));
+
+    let backend_meta: HashMap<String, BackendMeta> = [
+        (
+            "math".to_string(),
+            BackendMeta {
+                transport: "channel".to_string(),
+            },
+        ),
+        (
+            "text".to_string(),
+            BackendMeta {
+                transport: "channel".to_string(),
+            },
+        ),
+    ]
+    .into();
+
+    let admin_state = admin::spawn_health_checker(
+        proxy_for_admin,
+        "test-proxy".into(),
+        "1.0.0".into(),
+        2,
+        backend_meta,
+    );
+
+    // Config carries an admin_token so `admin_router` builds its auth layer.
+    let test_config = ProxyConfig::parse(&format!(
+        r#"
+        [proxy]
+        name = "test-proxy"
+        version = "1.0.0"
+        [proxy.listen]
+
+        [security]
+        admin_token = "{token}"
+
+        [[backends]]
+        name = "math"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "text"
+        transport = "stdio"
+        command = "echo"
+        "#
+    ))
+    .unwrap();
+
+    let router = router.nest(
+        "/admin",
+        admin::admin_router(
+            admin_state,
+            None,
+            session_handle,
+            None,
+            proxy_for_mgmt,
+            &test_config,
+            None,
+            std::collections::HashMap::new(),
+        ),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to random port");
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+
+    (addr, handle)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -249,6 +359,153 @@ async fn test_admin_config_endpoint() {
         body.contains("test-proxy"),
         "config should contain proxy name"
     );
+
+    handle.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Negative-path auth tests (issue #178)
+// ---------------------------------------------------------------------------
+//
+// The auth deny path -- the entire value of an auth gateway -- needs coverage
+// at the wired HTTP level, not just in per-module unit tests. These tests use
+// `spawn_proxy_server_with_bearer` to stand up the real stack (bearer auth on
+// the MCP endpoint, admin_token on `/admin/*`) and assert that the proxy
+// returns the right status when auth is missing, wrong, or malformed. The
+// admin pair is the end-to-end guard for the admin-protection fix in #174.
+//
+// Deliberately NOT covered here (deferred, not forgotten):
+//   - JWT-signature cases (expired token, `alg=none`, JWKS rotation): these
+//     require minting signed JWTs and a JWKS mock that this repo has no infra
+//     for. Signature validation lives in the `tower-mcp` dependency and the
+//     auth-gateway audit scoped it out of the proxy.
+//   - Introspection `aud` handling (#177), RBAC `default_deny` (#176), and
+//     per-token `required_scopes` (#175): each already has unit tests in its
+//     own module; re-testing them here would add no coverage.
+
+const TEST_TOKEN: &str = "sk-test-secret-token";
+
+/// MCP endpoint with no `Authorization` header is rejected with 401.
+#[tokio::test]
+async fn test_mcp_no_auth_header_rejected() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/", addr);
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("POST /");
+    assert_eq!(resp.status(), 401, "missing Authorization must be 401");
+
+    handle.abort();
+}
+
+/// MCP endpoint with a wrong/garbage bearer token is rejected with 401.
+#[tokio::test]
+async fn test_mcp_wrong_token_rejected() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/", addr);
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Authorization", "Bearer not-the-right-token")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("POST /");
+    assert_eq!(resp.status(), 401, "wrong bearer token must be 401");
+
+    handle.abort();
+}
+
+/// MCP endpoint with a malformed `Authorization` header (an unsupported auth
+/// scheme) is rejected with 401.
+///
+/// Note: `tower-mcp`'s `extract_api_key` intentionally accepts a *raw* key with
+/// no scheme prefix (e.g. `Authorization: <token>`), so a prefix-less but
+/// otherwise-correct token would pass. The genuinely-malformed case the
+/// validator rejects is an unrecognized scheme such as Basic auth: it contains
+/// a space and is neither `Bearer ` nor `ApiKey `, so no token is extracted.
+#[tokio::test]
+async fn test_mcp_malformed_auth_header_rejected() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/", addr);
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        // Unsupported scheme -- the validator cannot extract a token.
+        .header("Authorization", "Basic dXNlcjpwYXNzd29yZA==")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("POST /");
+    assert_eq!(resp.status(), 401, "malformed Authorization must be 401");
+
+    handle.abort();
+}
+
+/// Sanity check: with the correct bearer token, the MCP endpoint does NOT
+/// return 401 -- auth passes and the request reaches the handler. (The exact
+/// non-401 status depends on the MCP handler; we only assert auth let it
+/// through.)
+#[tokio::test]
+async fn test_mcp_correct_token_passes_auth() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/", addr);
+
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .bearer_auth(TEST_TOKEN)
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("POST /");
+    assert_ne!(
+        resp.status(),
+        401,
+        "correct bearer token must pass auth (got {})",
+        resp.status()
+    );
+
+    handle.abort();
+}
+
+/// `/admin/*` with no token is rejected with 401. This is the end-to-end guard
+/// for the admin-protection fix in #174.
+#[tokio::test]
+async fn test_admin_no_token_rejected() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/admin/backends", addr);
+
+    let resp = reqwest::get(&url).await.expect("GET /admin/backends");
+    assert_eq!(resp.status(), 401, "admin without token must be 401");
+
+    handle.abort();
+}
+
+/// `/admin/*` with the correct admin token returns 200.
+#[tokio::test]
+async fn test_admin_correct_token_allowed() {
+    let (addr, handle) = spawn_proxy_server_with_bearer(TEST_TOKEN).await;
+    let url = format!("http://{}/admin/backends", addr);
+
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(TEST_TOKEN)
+        .send()
+        .await
+        .expect("GET /admin/backends");
+    assert_eq!(resp.status(), 200, "admin with correct token must be 200");
 
     handle.abort();
 }


### PR DESCRIPTION
Closes #178.

## What

HTTP-level negative-auth tests in `tests/http_e2e.rs` (single file, +257). New helper `spawn_proxy_server_with_bearer(token)` mirrors `apply_auth` (wraps the MCP router with `AuthLayer`/`StaticBearerValidator` before the `/admin` nest) and passes a config with `security.admin_token` so `admin_router` builds its own independent auth layer.

Six tests:
- MCP `POST /`, no `Authorization` -> 401
- MCP, wrong bearer token -> 401
- MCP, malformed `Authorization` (unsupported scheme) -> 401
- MCP, correct token -> not 401 (auth-passes sanity)
- `/admin/backends`, no token -> 401  *(end-to-end guard for the #174 admin-protection fix)*
- `/admin/backends`, correct token -> 200

## Scope (deliberate)

Documented at the test-group header. Out of scope here:
- JWT-signature cases (expired, `alg=none`, JWKS) -- need token signing + a JWKS mock this repo has no infra for, and that validation lives in `tower-mcp`. No new dev-deps were added.
- Introspection `aud` (#177), RBAC `default_deny` (#176), `required_scopes` (#175) -- each already has module unit tests from its own PR.

## Finding surfaced (non-blocking)

While writing the malformed-header case: tower-mcp's `extract_api_key` accepts a raw, **prefix-less** token (`Authorization: <token>` with no `Bearer `) as valid, as long as it contains no space. Not a bypass -- the caller still needs the valid token -- but a prefix-less token is treated as valid. The test therefore uses an unsupported scheme (`Basic ...`) for the genuine-rejection assertion, with a comment explaining why. Worth a look upstream if stricter `Bearer`-only parsing is desired.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib --all-features`, `cargo test --test http_e2e --all-features` (11 passed) -- all green.

Implemented via roba; orchestrator reviewed assertions (strict, not weakened) and the deferral boundary before push.