### PR TITLE
chore: upgrade tower-mcp 0.9.2 -> 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1508,7 +1508,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2103,7 +2103,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2528,7 +2528,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2566,7 +2566,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2968,7 +2968,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3026,7 +3026,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3366,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3464,7 +3464,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3827,9 +3827,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.9.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c31b3fe4747f7223020932006b1aa8f077e5dfb3642b2dae2d1001ed06a3c"
+checksum = "96dd7df8b3c0f729ce9f294059f501fd8b1c53760bf61079c1433380fe66d76b"
 dependencies = [
  "async-trait",
  "axum",
@@ -3845,6 +3845,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3856,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.9.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d0e783ebb50f9449cc26b1ac5f82318efa042d474662304e9d45c95b8960e9"
+checksum = "6511f1f32c7cb7fd4525edc0eb4dcf307db8f7eceb2833ab24a37b4cc10cda61"
 dependencies = [
  "base64",
  "serde",
@@ -4489,7 +4490,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ redis-cache = ["dep:redis"]
 sqlite-cache = ["dep:rusqlite"]
 
 [dependencies]
-tower-mcp = { version = "0.9.0", features = ["http", "http-client", "proxy"] }
-tower-mcp-types = "0.9.0"
+tower-mcp = { version = "0.12.0", features = ["http", "http-client", "proxy"] }
+tower-mcp-types = "0.12.0"
 axum = "0.8"
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
 tower-resilience = { version = "0.9.3", default-features = false, features = ["circuitbreaker", "ratelimiter", "hedge", "retry"] }
@@ -70,7 +70,7 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 reqwest = { version = "0.13", features = ["json"] }
 tokio-stream = "0.1"
 tower-resilience-chaos = "0.9"
-tower-mcp = { version = "0.9.0", features = ["http", "http-client", "proxy", "websocket"] }
+tower-mcp = { version = "0.12.0", features = ["http", "http-client", "proxy", "websocket"] }
 futures-util = "0.3"
 docker-wrapper = { version = "0.11.1", features = ["testing", "templates"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/outlier.rs
+++ b/src/outlier.rs
@@ -581,6 +581,8 @@ mod tests {
                 tower_mcp_types::protocol::ListToolsResult {
                     tools: vec![],
                     next_cursor: None,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 },
             )),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -182,6 +182,8 @@ mod tests {
                 tower_mcp_types::protocol::ListToolsResult {
                     tools: vec![],
                     next_cursor: None,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 },
             )),

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -56,6 +56,8 @@ impl Service<RouterRequest> for MockService {
                 McpRequest::ListTools(_) => Ok(McpResponse::ListTools(ListToolsResult {
                     tools,
                     next_cursor: None,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 })),
                 McpRequest::CallTool(params) => Ok(McpResponse::CallTool(CallToolResult::text(


### PR DESCRIPTION
## Summary

Bumps `tower-mcp` and `tower-mcp-types` from 0.9.2 to 0.12.0 (three minor releases).

A scoping spike confirmed the **library/runtime code is fully compatible** -- nothing the proxy uses (auth, proxy, transport) changed API. The only breakage is in test/mock code:

- tower-mcp's SEP-2549 client-cache-TTL feature added two `Option` fields to `ListToolsResult`: `ttl_ms: Option<u64>` and `cache_scope: Option<CacheScope>`.
- Three sites construct `ListToolsResult` with struct literals (all test/mock helpers): `src/test_util.rs`, `src/outlier.rs`, `src/retry.rs`. Each now sets `ttl_ms: None, cache_scope: None` (no behavior change -- mocks don't exercise cache TTL).

## Verification

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- `cargo test --all-features` -- 292 lib tests + integration/e2e/http_e2e all green

## Context

First of a dependency-currency pass (audit was clean of CVEs; these are staying-current bumps). Next up, tracked separately: OpenTelemetry 0.29->0.32 set, toml 1.0, notify 8, optional cache backends (redis 1.0, rusqlite).