### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2026-08-04
+
+### Bug Fixes
+
+- Prepare v0.4.1 release automation ([#194](https://github.com/joshrotenberg/mcp-proxy/pull/194))
+
+### Features
+
+- Refresh protocol and maintenance baseline ([#191](https://github.com/joshrotenberg/mcp-proxy/pull/191))
+
+
+
 ## [0.4.0] - 2026-06-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.90"
 description = "Tower-native MCP gateway for aggregating backends with auth, resilience, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1] - 2026-08-04

### Bug Fixes

- Prepare v0.4.1 release automation ([#194](https://github.com/joshrotenberg/mcp-proxy/pull/194))

### Features

- Refresh protocol and maintenance baseline ([#191](https://github.com/joshrotenberg/mcp-proxy/pull/191))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).