### PR TITLE
docs: add a production gateway showcase (closes #197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ All tools from the filesystem server are now available under the `files/` namesp
 
 See [`config.example.toml`](config.example.toml) for the full configuration reference with all options documented.
 
+For a complete production example (ten backends behind one endpoint, with JWT/RBAC, per-backend resilience, a mirrored canary, selective caching, and metrics), see [docs/production-gateway.md](docs/production-gateway.md) and [`examples/production-gateway.toml`](examples/production-gateway.toml).
+
 ### Per-backend middleware
 
 ```toml

--- a/docs/production-gateway.md
+++ b/docs/production-gateway.md
@@ -1,0 +1,148 @@
+# Production gateway showcase
+
+One config file that shows why the proxy exists: ten internal MCP services
+behind a single authenticated endpoint, each with the middleware its failure
+modes deserve, plus a canary receiving mirrored production traffic.
+
+The full config is [`examples/production-gateway.toml`](../examples/production-gateway.toml).
+Validate it without starting anything:
+
+```bash
+mcp-proxy --config examples/production-gateway.toml --check
+```
+
+```text
+Config OK
+
+  Proxy:    gateway v1.0.0
+  Listen:   0.0.0.0:8080
+  Backends: 10
+    - github (stdio) [timeout, rate-limit, circuit-breaker, retry, filter]
+    - jira (http) [timeout, concurrency-limit]
+    - docs (http) [timeout, hedging, cache, filter]
+    - search (http) [timeout, hedging, filter]
+    - db-analytics (stdio) [timeout, concurrency-limit, cache, filter]
+    - orders-api (http) [timeout, circuit-breaker, retry, outlier-detection]
+    - orders-canary (http) [mirror]
+    - payments (http) [timeout, rate-limit, concurrency-limit, filter]
+    - reports (http) [timeout, rate-limit, cache, filter]
+    - legacy-crm (http) [timeout, circuit-breaker, retry, outlier-detection]
+  Auth:     jwt/jwks
+  Request coalescing: enabled
+  Audit logging: enabled
+  Metrics: enabled
+```
+
+## Request flow
+
+```
+Claude Code / IDEs / agents
+        |
+        |  HTTP + JWT bearer token
+        v
++---------------------------- mcp-proxy :8080 ----------------------------+
+|                                                                         |
+|  [JWT verify] -> [audit log] -> [metrics] -> [RBAC tool visibility]     |
+|      -> [capability filter] -> [argument validation]                    |
+|      -> [coalesce identical calls] -> [response cache]                  |
+|      -> [mirror tap] -> route by namespace                              |
+|                            |                                            |
+|   +------------------------+--------------------------+                 |
+|   v                        v                          v                 |
+|  github/*               orders-api/*               payments/*  ...      |
+|  [retry]                [retry]                    [rate limit]         |
+|  [rate limit]           [circuit breaker]          [concurrency]        |
+|  [timeout]              [outlier detection]        [timeout]            |
+|  [circuit breaker]      [timeout]                                       |
+|   |                      |        \                    |                |
++---|----------------------|---------\-------------------|----------------+
+    v                      v          \ 10% copy          v
+  GitHub API          orders-v1        '-> orders-v2    payments service
+  (stdio child)       (production)         (staging,    (HTTP, internal)
+                                           responses
+                                           discarded)
+```
+
+Global middleware runs once per request; each backend then applies its own
+resilience chain. The mirror tap forks a fire-and-forget copy of matching
+requests to the canary; the client only ever sees the primary's response.
+
+## Which setting solves which concern
+
+| Operational concern | Setting | Where in the example |
+|---|---|---|
+| Only authenticated clients get in | `[auth] type = "jwt"` with JWKS | global |
+| A role sees only the tools it needs | `[[auth.roles]]` + `[auth.role_mapping]` | `developer`, `analyst`, `operator` |
+| Dangerous tools are not exposed at all | `expose_tools` / `hide_tools` | `payments`, `github` |
+| A slow backend cannot hold requests forever | `[backends.timeout]` | every backend |
+| Third-party API limits are respected | `[backends.rate_limit]` | `github` (30/s), `reports` (2/s) |
+| A failing backend stops receiving traffic | `[backends.circuit_breaker]` | `github`, `orders-api`, `legacy-crm` |
+| Transient failures are retried, without retry storms | `[backends.retry]` with `budget_percent` | `github`, `orders-api` |
+| Tail latency on read-only lookups is cut | `[backends.hedging]` | `docs`, `search` |
+| The database sees a bounded connection count | `[backends.concurrency]` | `db-analytics` (5), `payments` (2) |
+| A misbehaving instance is temporarily ejected | `[backends.outlier_detection]` | `orders-api`, `legacy-crm` |
+| v2 is validated against real traffic, invisibly | `mirror_of` + `mirror_percent` | `orders-canary` |
+| Hot repeated reads skip the backend | `[backends.cache]` | `docs`, `db-analytics`, `reports` |
+| Identical concurrent calls run once | `[performance] coalesce_requests` | global |
+| Oversized arguments are rejected early | `[security] max_argument_size` | global |
+| Every call is attributable | `[observability] audit` (JSON logs) | global |
+| Dashboards and alerts have data | `[observability.metrics]` + `/admin/metrics` | global |
+| Live state is inspectable | `/admin/backends`, `/admin/health`, `/admin/cache/stats` | global |
+| The admin surface has its own credential | `[security] admin_token` | global |
+
+## Safety: middleware that re-executes or short-circuits tool calls
+
+Four middlewares change how many times a tool call actually executes, or
+whether it executes at all. They are safe on read-only tools and need care on
+mutating ones. The proxy cannot know which tools mutate; you declare it by
+construction, with `expose_tools` and per-backend placement.
+
+**Caching short-circuits execution.** `tool_ttl_seconds` caches every tool on
+that backend; there is no per-tool cacheability flag. Cache only backends
+whose exposed tools are read-only, and use `expose_tools` to make that true
+by construction (`docs`, `db-analytics`, `reports` here). A cached
+`create_refund` would return a stale success without executing; accordingly,
+`payments`, `jira`, `orders-api`, and `legacy-crm` have no cache block.
+
+**Mirroring re-executes for real.** A mirrored tool call is not a dry run:
+the canary receives and executes it. Mirror only backends whose state you
+can afford to touch twice, or point the canary at isolated state. Here
+`orders-canary` targets `orders-v2.staging.internal`, so mirrored writes land
+in staging, never in production data.
+
+**Hedging duplicates in-flight calls.** When the original request is slow, a
+hedge fires a second copy and the first response wins, so a single client
+call can execute twice on the backend. Only `docs` and `search`, read-only by
+`expose_tools`, are hedged. Never hedge a backend with mutating tools.
+
+**Retries re-execute after ambiguous failures.** A timeout can fire after the
+backend applied the change, so a retry may double-execute. Retries here sit
+on backends whose tools are read-dominant or idempotent (`github`,
+`orders-api`, one cautious retry on `legacy-crm`), with `budget_percent`
+capping retry volume during incidents. `payments` gets no retries: a failed
+refund is investigated, not replayed.
+
+Request coalescing collapses identical concurrent calls (same backend, tool,
+and arguments) into one execution and fans the response out. That is the
+point for reads; for mutating tools it means N identical concurrent submits
+execute once, which is usually acceptable but worth knowing.
+
+## Operating it
+
+- Scrape `GET /admin/metrics` with Prometheus; request counts and duration
+  histograms are labeled per backend.
+- `GET /admin/health` for liveness dashboards, `GET /admin/backends` for
+  per-backend health and middleware, `GET /admin/cache/stats` for hit rates.
+- With JWT auth, the admin API requires `[security] admin_token`; send it as
+  a bearer token.
+- Run `mcp-proxy --config ... --check` in CI so config drift fails before
+  deploy, not at startup. It also warns on references to unset environment
+  variables (`${GITHUB_TOKEN}`, `${ADMIN_TOKEN}`, `${ANALYTICS_DB_URL}` here).
+
+## What this example leaves out
+
+Failover chains (`failover_for`), weighted canary routing (`canary_of` +
+`weight`, when you want the canary to serve real responses), tool aliasing,
+argument injection, composite tools, and hot reload are covered in
+[`config.example.toml`](../config.example.toml) and
+[architectures.md](architectures.md).

--- a/examples/production-gateway.toml
+++ b/examples/production-gateway.toml
@@ -1,0 +1,279 @@
+# Production gateway showcase
+#
+# Ten internal MCP services behind one authenticated endpoint, with
+# per-backend resilience, a canary receiving mirrored traffic, selective
+# caching, request coalescing, and Prometheus metrics.
+#
+# Walkthrough: docs/production-gateway.md
+# Validate:    mcp-proxy --config examples/production-gateway.toml --check
+
+[proxy]
+name = "gateway"
+version = "1.0.0"
+separator = "/"
+instructions = "Company MCP gateway. Tools are namespaced by service. Access is role-based; ask #platform for a scope."
+
+[proxy.listen]
+host = "0.0.0.0"
+port = 8080
+
+# =============================================================================
+# Authentication: JWT via the corporate IdP, roles from the scope claim
+# =============================================================================
+
+[auth]
+type = "jwt"
+issuer = "https://idp.corp.example"
+audience = "mcp-proxy"
+jwks_uri = "https://idp.corp.example/.well-known/jwks.json"
+
+# Role-based tool visibility. A role lists the tools it may see and call;
+# an empty role means all tools.
+[[auth.roles]]
+name = "developer"
+allow_tools = ["github/*", "jira/*", "docs/*", "search/*"]
+
+[[auth.roles]]
+name = "analyst"
+allow_tools = ["docs/*", "search/*", "db-analytics/*", "reports/*"]
+
+[[auth.roles]]
+name = "operator"
+allow_tools = [
+    "orders-api/*",
+    "payments/refund_status",
+    "payments/create_refund",
+    "legacy-crm/*",
+    "search/*",
+]
+
+[[auth.roles]]
+name = "admin"
+# all tools
+
+[auth.role_mapping]
+claim = "scope"
+mapping = { "mcp:dev" = "developer", "mcp:analyst" = "analyst", "mcp:ops" = "operator", "mcp:admin" = "admin" }
+
+# =============================================================================
+# Backends
+# =============================================================================
+
+# Third-party API via stdio. Rate-limited to respect GitHub's API limits,
+# circuit breaker and budgeted retries for flaky network days.
+[[backends]]
+name = "github"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+hide_tools = ["delete_repository", "delete_branch"]
+
+[backends.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "${GITHUB_TOKEN}"
+
+[backends.timeout]
+seconds = 60
+
+[backends.rate_limit]
+requests = 30
+period_seconds = 1
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.5
+minimum_calls = 10
+wait_duration_seconds = 30
+
+[backends.retry]
+max_retries = 3
+initial_backoff_ms = 100
+max_backoff_ms = 5000
+budget_percent = 20.0
+
+# Internal issue tracker. Mixed read/write tools, so no cache and no hedging.
+[[backends]]
+name = "jira"
+transport = "http"
+url = "http://jira-mcp.internal:8080"
+
+[backends.timeout]
+seconds = 30
+
+[backends.concurrency]
+max_concurrent = 20
+
+# Documentation search. Read-only by construction (expose_tools), which makes
+# caching and hedging safe.
+[[backends]]
+name = "docs"
+transport = "http"
+url = "http://confluence-mcp.internal:8080"
+expose_tools = ["search", "get_page", "list_spaces"]
+
+[backends.timeout]
+seconds = 30
+
+[backends.cache]
+tool_ttl_seconds = 60
+resource_ttl_seconds = 300
+max_entries = 1000
+
+[backends.hedging]
+delay_ms = 200
+max_hedges = 1
+
+# Internal code/knowledge search. Read-only; hedged for tail latency.
+[[backends]]
+name = "search"
+transport = "http"
+url = "http://search-mcp.internal:8080"
+expose_tools = ["query", "similar"]
+
+[backends.timeout]
+seconds = 10
+
+[backends.hedging]
+delay_ms = 150
+max_hedges = 1
+
+# Read replica of the analytics database. Connection count capped, queries
+# cached for a minute.
+[[backends]]
+name = "db-analytics"
+transport = "stdio"
+command = "/usr/local/bin/db-mcp-server"
+args = ["--read-only", "--connection-string", "${ANALYTICS_DB_URL}"]
+expose_tools = ["query"]
+
+[backends.timeout]
+seconds = 10
+
+[backends.concurrency]
+max_concurrent = 5
+
+[backends.cache]
+tool_ttl_seconds = 60
+max_entries = 500
+
+# Order service, current production version. The canary below mirrors it.
+[[backends]]
+name = "orders-api"
+transport = "http"
+url = "http://orders-v1.internal:8080"
+
+[backends.timeout]
+seconds = 15
+
+[backends.retry]
+max_retries = 2
+initial_backoff_ms = 50
+max_backoff_ms = 1000
+budget_percent = 10.0
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.5
+minimum_calls = 10
+wait_duration_seconds = 20
+
+[backends.outlier_detection]
+consecutive_errors = 5
+base_ejection_seconds = 30
+max_ejection_percent = 50
+
+# Order service v2 canary. Receives a fire-and-forget copy of 10% of
+# orders-api traffic; responses are discarded and clients never see it.
+# It points at STAGING state: mirrored tool calls really execute.
+[[backends]]
+name = "orders-canary"
+transport = "http"
+url = "http://orders-v2.staging.internal:8080"
+mirror_of = "orders-api"
+mirror_percent = 10
+
+# Payment operations. Deliberately spartan: no cache, no retries, no hedging,
+# tight limits. Only two tools are exposed at all.
+[[backends]]
+name = "payments"
+transport = "http"
+url = "http://payments-mcp.internal:8080"
+expose_tools = ["refund_status", "create_refund"]
+
+[backends.timeout]
+seconds = 20
+
+[backends.rate_limit]
+requests = 5
+period_seconds = 1
+
+[backends.concurrency]
+max_concurrent = 2
+
+# Reporting warehouse. Slow queries, long timeout, aggressive caching,
+# low request rate.
+[[backends]]
+name = "reports"
+transport = "http"
+url = "http://warehouse-mcp.internal:8080"
+expose_tools = ["run_report", "list_reports"]
+
+[backends.timeout]
+seconds = 120
+
+[backends.rate_limit]
+requests = 2
+period_seconds = 1
+
+[backends.cache]
+tool_ttl_seconds = 600
+resource_ttl_seconds = 900
+max_entries = 200
+
+# Vendor CRM with a history of bad days. Breaker trips fast, unhealthy
+# instances are ejected, one cautious retry.
+[[backends]]
+name = "legacy-crm"
+transport = "http"
+url = "http://crm-bridge.internal:8080"
+
+[backends.timeout]
+seconds = 45
+
+[backends.retry]
+max_retries = 1
+initial_backoff_ms = 500
+max_backoff_ms = 500
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.3
+minimum_calls = 5
+wait_duration_seconds = 60
+
+[backends.outlier_detection]
+consecutive_errors = 3
+base_ejection_seconds = 60
+max_ejection_percent = 100
+
+# =============================================================================
+# Global middleware
+# =============================================================================
+
+# Collapse identical concurrent tool calls into one backend execution.
+[performance]
+coalesce_requests = true
+
+[security]
+max_argument_size = 1048576
+# Required when auth.type is jwt: the /admin API needs its own token.
+admin_token = "${ADMIN_TOKEN}"
+
+[observability]
+audit = true
+log_level = "info"
+json_logs = true
+
+[observability.metrics]
+enabled = true
+
+[observability.tracing]
+enabled = true
+endpoint = "http://otel-collector.internal:4317"
+service_name = "mcp-proxy"


### PR DESCRIPTION
## Context

The README and examples show individual features, but nothing demonstrates the proxy end to end: many services, one authenticated endpoint, per-backend resilience, a canary, caching, and metrics in a single coherent config. Issue #197 asks for one compact, copyable showcase.

## Plan

1. Add `examples/production-gateway.toml`: ten backends behind one endpoint with JWT/JWKS auth and four RBAC roles, per-backend timeout/retry/circuit breaker/rate limiting where each fits, a staging canary receiving 10% mirrored traffic from the orders backend, selective caching on read-only backends, global request coalescing, audit logging, metrics, and tracing. The config passes `mcp-proxy --config ... --check`.
2. Add `docs/production-gateway.md`: request-flow sketch, a concern-to-setting table mapping each operational concern to the config block that addresses it, and safety guidance for middleware that re-executes or short-circuits tool calls (caching, mirroring, hedging, retries, coalescing) with the read-only-by-construction pattern via `expose_tools`.
3. Link the walkthrough from the README Configuration section.

## Constraints

- Docs and example config only; no code changes.
- The example must validate with `--check` as committed.
- No performance claims.

Closes #197.