### PR TITLE
test: gate feature-dependent config tests behind their features (closes #203)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3189,9 +3189,7 @@ mod tests {
         assert!(err.to_string().contains("unknown cache backend"));
     }
 
-    #[test]
-    fn test_cache_backend_redis_with_url() {
-        let toml = r#"
+    const REDIS_CACHE_CONFIG: &str = r#"
         [proxy]
         name = "test"
         [proxy.listen]
@@ -3205,10 +3203,56 @@ mod tests {
         transport = "stdio"
         command = "echo"
         "#;
-        let config = ProxyConfig::parse(toml).unwrap();
+
+    #[cfg(feature = "redis-cache")]
+    #[test]
+    fn test_cache_backend_redis_with_url() {
+        let config = ProxyConfig::parse(REDIS_CACHE_CONFIG).unwrap();
         assert_eq!(config.cache.backend, "redis");
         assert_eq!(config.cache.url.as_deref(), Some("redis://localhost:6379"));
         assert_eq!(config.cache.prefix, "myapp:");
+    }
+
+    #[cfg(not(feature = "redis-cache"))]
+    #[test]
+    fn test_cache_backend_redis_rejected_without_feature() {
+        let err = ProxyConfig::parse(REDIS_CACHE_CONFIG).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("requires the 'redis-cache' feature")
+        );
+    }
+
+    const SQLITE_CACHE_CONFIG: &str = r#"
+        [proxy]
+        name = "test"
+        [proxy.listen]
+        [cache]
+        backend = "sqlite"
+        url = "cache.db"
+
+        [[backends]]
+        name = "echo"
+        transport = "stdio"
+        command = "echo"
+        "#;
+
+    #[cfg(feature = "sqlite-cache")]
+    #[test]
+    fn test_cache_backend_sqlite_with_url() {
+        let config = ProxyConfig::parse(SQLITE_CACHE_CONFIG).unwrap();
+        assert_eq!(config.cache.backend, "sqlite");
+        assert_eq!(config.cache.url.as_deref(), Some("cache.db"));
+    }
+
+    #[cfg(not(feature = "sqlite-cache"))]
+    #[test]
+    fn test_cache_backend_sqlite_rejected_without_feature() {
+        let err = ProxyConfig::parse(SQLITE_CACHE_CONFIG).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("requires the 'sqlite-cache' feature")
+        );
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -44,6 +44,8 @@ impl Proxy {
     pub async fn from_config(config: ProxyConfig) -> Result<Self> {
         let (mcp_proxy, cb_handles) = build_mcp_proxy(&config).await?;
         let proxy_for_admin = mcp_proxy.clone();
+        // Only the discovery index build mutates this clone.
+        #[cfg_attr(not(feature = "discovery"), allow(unused_mut))]
         let mut proxy_for_caller = mcp_proxy.clone();
         let proxy_for_management = mcp_proxy.clone();
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1106,9 +1106,7 @@ mod config_tests {
         );
     }
 
-    #[test]
-    fn config_tool_exposure_search_parses() {
-        let toml = r#"
+    const TOOL_EXPOSURE_SEARCH_CONFIG: &str = r#"
         [proxy]
         name = "test"
         tool_exposure = "search"
@@ -1119,11 +1117,22 @@ mod config_tests {
         transport = "stdio"
         command = "echo"
         "#;
-        let config = ProxyConfig::parse(toml).unwrap();
+
+    #[cfg(feature = "discovery")]
+    #[test]
+    fn config_tool_exposure_search_parses() {
+        let config = ProxyConfig::parse(TOOL_EXPOSURE_SEARCH_CONFIG).unwrap();
         assert_eq!(
             config.proxy.tool_exposure,
             mcp_proxy::config::ToolExposure::Search
         );
+    }
+
+    #[cfg(not(feature = "discovery"))]
+    #[test]
+    fn config_tool_exposure_search_rejected_without_feature() {
+        let err = ProxyConfig::parse(TOOL_EXPOSURE_SEARCH_CONFIG).unwrap_err();
+        assert!(err.to_string().contains("requires the 'discovery' feature"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

`cargo test` with default features fails on `config::tests::test_cache_backend_redis_with_url`, which parses a `cache.backend = "redis"` config without being gated on the `redis-cache` feature. CI never catches this because it only runs `--all-features` (#202). This PR fixes the default run and the siblings found by auditing all three supported feature points, so the CI matrix in #204 can land.

## What the audit found

Running tests and clippy at default, `--no-default-features`, and `--all-features` surfaced three issues:

1. `config::tests::test_cache_backend_redis_with_url` (src/config.rs): expects redis cache config to parse; fails without the `redis-cache` feature.
2. `config_tests::config_tool_exposure_search_parses` (tests/e2e.rs): expects `tool_exposure = "search"` to parse; fails without the `discovery` feature. Previously masked because the lib test failure aborted the run before the e2e binary executed.
3. `src/proxy.rs`: `let mut proxy_for_caller` is only mutated by the discovery index build, so `clippy --no-default-features -- -D warnings` fails on `unused_mut`. This is the one production-code touch: a `cfg_attr` allow scoped to non-discovery builds.

## Changes

- Gate the redis success test on `redis-cache`; add a `cfg(not(...))` twin asserting the documented rejection error.
- Add the missing sqlite pair (`sqlite-cache` success test and rejection twin); sqlite had no success-path coverage at all.
- Gate the search exposure success test on `discovery`; add its rejection twin.
- `#[cfg_attr(not(feature = "discovery"), allow(unused_mut))]` on `proxy_for_caller`.

The rejection twins mean every build shape now tests its own contract: with the feature, the config parses; without it, the documented error appears.

## Verification

`cargo fmt --check`, `cargo test`, and `cargo clippy --all-targets -- -D warnings` all pass at default, `--no-default-features`, and `--all-features`.

Closes #203.