### PR TITLE
ci: test default and no-default-features builds (closes #204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,25 @@ jobs:
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
-    name: Test
+    name: Test (${{ matrix.features }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - features: all
+            flags: --all-features
+          - features: default
+            flags: ""
+          - features: none
+            flags: --no-default-features
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+        with:
+          key: ${{ matrix.features }}
+      - run: cargo test ${{ matrix.flags }}
 
   msrv:
     name: MSRV (1.90)


### PR DESCRIPTION
## Context

CI runs `cargo test --all-features` only. The default-features and `--no-default-features` builds the README advertises were never exercised, which let the feature-gating bugs fixed in #214 sit undetected. With those fixed, the matrix can land.

## Plan

1. Convert the test job to a three-leg matrix: `--all-features`, default features, `--no-default-features`, with `fail-fast: false` and per-leg cache keys.
2. Leave clippy as a single `--all-features` job.
3. No required-check pinning exists in the branch ruleset, so renaming the job to `Test (...)` is safe.

Closes #204.