### PR TITLE
test: validate example configs and fix schema drift (closes #212)

### DIFF
--- a/examples/cost-optimization.toml
+++ b/examples/cost-optimization.toml
@@ -85,8 +85,8 @@ max_backoff_ms = 5000
 name = "cloud"
 transport = "http"
 url = "http://cloud-mcp.internal:8080"
+# Allowlist only; everything else (create/delete/resize instances) stays hidden
 expose_tools = ["list_instances", "get_costs", "get_metrics"]
-hide_tools = ["create_instance", "delete_instance", "resize_instance"]
 
 [backends.rate_limit]
 requests = 2

--- a/examples/gateway-auth.toml
+++ b/examples/gateway-auth.toml
@@ -1,10 +1,10 @@
 # Test config with bearer auth
 
-[gateway]
+[proxy]
 name = "auth-gateway"
 version = "0.1.0"
 
-[gateway.listen]
+[proxy.listen]
 host = "127.0.0.1"
 port = 8081
 

--- a/examples/gateway-filter.toml
+++ b/examples/gateway-filter.toml
@@ -1,11 +1,11 @@
 # Test config with capability filtering
 
-[gateway]
+[proxy]
 name = "filter-gateway"
 version = "0.1.0"
 separator = "/"
 
-[gateway.listen]
+[proxy.listen]
 host = "127.0.0.1"
 port = 8082
 

--- a/examples/gateway-validation.toml
+++ b/examples/gateway-validation.toml
@@ -1,11 +1,11 @@
 # Test config with capability filtering + request validation
 
-[gateway]
+[proxy]
 name = "validation-gateway"
 version = "0.1.0"
 separator = "/"
 
-[gateway.listen]
+[proxy.listen]
 host = "127.0.0.1"
 port = 8083
 

--- a/examples/gateway.toml
+++ b/examples/gateway.toml
@@ -1,11 +1,11 @@
 # Test config for local development
 
-[gateway]
+[proxy]
 name = "test-gateway"
 version = "0.1.0"
 separator = "/"
 
-[gateway.listen]
+[proxy.listen]
 host = "127.0.0.1"
 port = 8080
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,0 +1,52 @@
+//! Every example config must stay valid against the current schema.
+//!
+//! Walks examples/ recursively and runs each .toml through [`ProxyConfig::load`].
+//! Builds without an optional feature skip examples that fail with the
+//! documented "requires the '<feature>' feature" error, so this test holds at
+//! every feature point (default, --no-default-features, --all-features).
+
+use std::path::{Path, PathBuf};
+
+use mcp_proxy::ProxyConfig;
+
+fn collect_tomls(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read examples dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_tomls(&path, out);
+        } else if path.extension().is_some_and(|e| e == "toml") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn example_configs_are_valid() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let mut tomls = Vec::new();
+    collect_tomls(&dir, &mut tomls);
+    tomls.sort();
+    assert!(
+        !tomls.is_empty(),
+        "no example configs found under {}",
+        dir.display()
+    );
+
+    let mut failures = Vec::new();
+    for path in &tomls {
+        if let Err(err) = ProxyConfig::load(path) {
+            let msg = format!("{err:#}");
+            // A build without an optional feature rejects configs that use it
+            // with the documented error; that is the contract, not drift.
+            if msg.contains("requires the '") && msg.contains("' feature") {
+                continue;
+            }
+            failures.push(format!("{}: {msg}", path.display()));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "invalid example configs:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
## Context

Five shipped example configs fail `mcp-proxy --check` today (see the failure table on #212): four `gateway*.toml` files still use the pre-rename `[gateway]` table instead of `[proxy]`, and `cost-optimization.toml` sets both `expose_tools` and `hide_tools` on one backend, which the validator rejects. Nothing guards examples against schema drift.

## Plan

1. Fix the four `gateway*.toml` files: rename `[gateway]` and `[gateway.listen]` tables to `[proxy]` and `[proxy.listen]`.
2. Fix `cost-optimization.toml`: keep the `expose_tools` allowlist and drop the redundant `hide_tools` line (an allowlist already hides everything not on it).
3. Add `tests/examples.rs`: walks examples/ recursively for .toml files, runs each through `ProxyConfig::load`, and fails on any error except the documented "requires the '...' feature" rejection, which is skipped so the test is valid at every feature point (verified: `multi-instance-redis.toml` under a minimal build hits exactly that error).
4. Verify the test passes at default, `--no-default-features`, and `--all-features`, and that every example passes `--check` under `--all-features`.

Closes #212.