### PR TITLE
test: property tests for config parse and validation (closes #213)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1897,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "proptest",
  "redis",
  "regex",
  "reqwest 0.13.4",
@@ -2428,6 +2444,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2499,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2626,6 +2667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3031,6 +3081,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4079,6 +4141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,6 +4273,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ docker-wrapper = { version = "0.11.1", features = ["testing", "templates"] }
 uuid = { version = "1", features = ["v4"] }
 tempfile = "3"
 criterion = { version = "0.8", features = ["async_tokio"] }
+proptest = "1.11.0"
 
 [[bench]]
 name = "proxy_overhead"

--- a/tests/config_properties.proptest-regressions
+++ b/tests/config_properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d70362c3a3a1742af598b520349bbc6dc246e7fe0ffdd5a1dcc4548d5c7fd457 # shrinks to percent = 101
+cc 5cec741a4ee12fdfdf0a6562513a521b0736d90df42b05171659d7d5cd3301ff # shrinks to weight = 101

--- a/tests/config_properties.rs
+++ b/tests/config_properties.rs
@@ -1,0 +1,165 @@
+//! Property tests for config parsing and validation (#213).
+//!
+//! Configs are generated as TOML strings and driven through
+//! [`ProxyConfig::parse`], the same path `--check` and startup use. Case
+//! counts are capped to keep the suite fast.
+
+use mcp_proxy::ProxyConfig;
+use proptest::prelude::*;
+
+/// A lowercase identifier that is safe to embed in TOML without escaping.
+fn ident() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,11}"
+}
+
+fn minimal_backend(name: &str) -> String {
+    format!(
+        r#"
+[[backends]]
+name = "{name}"
+transport = "stdio"
+command = "echo"
+"#
+    )
+}
+
+fn base_config(proxy_name: &str, port: u16) -> String {
+    format!(
+        r#"
+[proxy]
+name = "{proxy_name}"
+[proxy.listen]
+host = "127.0.0.1"
+port = {port}
+"#
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Parse never panics, whatever the input. Errors are fine; panics are not.
+    #[test]
+    fn parse_never_panics_on_arbitrary_input(s in ".{0,256}") {
+        let _ = ProxyConfig::parse(&s);
+    }
+
+    /// Parse never panics on TOML-shaped input either: a valid prefix with an
+    /// arbitrary tail exercises deeper parser states.
+    #[test]
+    fn parse_never_panics_on_toml_shaped_input(
+        name in ident(),
+        port in 1u16..,
+        tail in ".{0,200}",
+    ) {
+        let toml = format!("{}{}{tail}", base_config(&name, port), minimal_backend("b"));
+        let _ = ProxyConfig::parse(&toml);
+    }
+
+    /// A generated valid config round-trips: parse -> serialize -> parse ->
+    /// serialize is a fixed point (compared via the second serialization).
+    #[test]
+    fn valid_config_roundtrips(
+        proxy_name in ident(),
+        port in 1u16..,
+        backend_count in 1usize..4,
+        timeout_secs in 1u64..600,
+    ) {
+        let mut toml = base_config(&proxy_name, port);
+        for i in 0..backend_count {
+            toml.push_str(&minimal_backend(&format!("b{i}")));
+            toml.push_str(&format!("[backends.timeout]\nseconds = {timeout_secs}\n"));
+        }
+        let parsed = ProxyConfig::parse(&toml).expect("generated config is valid");
+        let ser1 = toml::to_string(&parsed).expect("config serializes");
+        let reparsed = ProxyConfig::parse(&ser1).expect("serialized config parses");
+        let ser2 = toml::to_string(&reparsed).expect("config re-serializes");
+        prop_assert_eq!(ser1, ser2);
+    }
+
+    /// mirror_of, canary_of, and failover_for referencing an unknown backend
+    /// are rejected, whatever the names involved.
+    #[test]
+    fn unknown_backend_references_are_rejected(
+        primary in ident(),
+        ghost in ident(),
+        role in 0usize..3,
+    ) {
+        prop_assume!(primary != ghost);
+        let field = ["mirror_of", "canary_of", "failover_for"][role];
+        let extra = if field == "mirror_of" { "mirror_percent = 10\n" } else { "" };
+        let toml = format!(
+            "{}{}{}{field} = \"{ghost}\"\n{extra}",
+            base_config("p", 8080),
+            minimal_backend(&primary),
+            minimal_backend("secondary"),
+        );
+        let err = ProxyConfig::parse(&toml).expect_err("unknown reference must be rejected");
+        prop_assert!(
+            format!("{err:#}").contains("unknown backend"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    /// Self-references are rejected for all three roles.
+    #[test]
+    fn self_references_are_rejected(name in ident(), role in 0usize..3) {
+        let field = ["mirror_of", "canary_of", "failover_for"][role];
+        let extra = if field == "mirror_of" { "mirror_percent = 10\n" } else { "" };
+        let toml = format!(
+            "{}{}{field} = \"{name}\"\n{extra}",
+            base_config("p", 8080),
+            minimal_backend(&name),
+        );
+        let err = ProxyConfig::parse(&toml).expect_err("self reference must be rejected");
+        prop_assert!(
+            format!("{err:#}").contains("itself"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    /// The documented canary weight bound (1-100) is enforced.
+    #[test]
+    fn canary_weight_out_of_bounds_is_rejected(weight in 101u32..10_000) {
+        let toml = format!(
+            "{}{}{}canary_of = \"primary\"\nweight = {weight}\n",
+            base_config("p", 8080),
+            minimal_backend("primary"),
+            minimal_backend("canary"),
+        );
+        let result = ProxyConfig::parse(&toml);
+        prop_assert!(
+            result.is_err(),
+            "weight {weight} is outside the documented 1-100 range and must be rejected"
+        );
+    }
+
+    /// The documented mirror_percent bound (0-100) is enforced.
+    #[test]
+    fn mirror_percent_out_of_bounds_is_rejected(percent in 101u32..10_000) {
+        let toml = format!(
+            "{}{}{}mirror_of = \"primary\"\nmirror_percent = {percent}\n",
+            base_config("p", 8080),
+            minimal_backend("primary"),
+            minimal_backend("mirror"),
+        );
+        let result = ProxyConfig::parse(&toml);
+        prop_assert!(
+            result.is_err(),
+            "mirror_percent {percent} is outside 0-100 and must be rejected"
+        );
+    }
+
+    /// Duplicate backend names are rejected.
+    #[test]
+    fn duplicate_backend_names_are_rejected(name in ident()) {
+        let toml = format!(
+            "{}{}{}",
+            base_config("p", 8080),
+            minimal_backend(&name),
+            minimal_backend(&name),
+        );
+        let result = ProxyConfig::parse(&toml);
+        prop_assert!(result.is_err(), "duplicate backend name '{}' must be rejected", name);
+    }
+}


### PR DESCRIPTION
## Context

src/config.rs is roughly 3200 lines of parse plus validation with example-based tests only. These property tests pin the documented contracts and probe the surface adversarially through `ProxyConfig::parse`, the same path `--check` and startup use.

## What landed

`tests/config_properties.rs` (proptest, 64 cases per property, ~0.03s):

- `parse_never_panics_on_arbitrary_input` and `parse_never_panics_on_toml_shaped_input`: parse returns errors, never panics, for arbitrary and TOML-prefixed inputs.
- `valid_config_roundtrips`: parse -> serialize -> parse -> serialize is a fixed point for generated valid configs.
- `unknown_backend_references_are_rejected` and `self_references_are_rejected`: `mirror_of`, `canary_of`, and `failover_for` reject unknown and self references for arbitrary generated names.
- `canary_weight_out_of_bounds_is_rejected` and `mirror_percent_out_of_bounds_is_rejected`: the documented percentage bounds hold.
- `duplicate_backend_names_are_rejected`.

The proptest-regressions file is committed so the failing seeds that found #226 stay pinned.

## Found and fixed along the way

The two bounds properties failed as written: `weight = 101` and `mirror_percent = 101` were accepted. Filed as #226 and fixed in PR #227 (merged); this PR's generative tests are the ongoing regression.

## Verification

`cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings` at default, `--no-default-features`, and `--all-features`: all green.

Closes #213.