### PR TITLE
fix: reject weight and mirror_percent above 100 (closes #226)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1634,6 +1634,13 @@ impl ProxyConfig {
                         backend.name
                     );
                 }
+                if backend.mirror_percent > 100 {
+                    anyhow::bail!(
+                        "backend '{}': mirror_percent must be 0-100, got {}",
+                        backend.name,
+                        backend.mirror_percent
+                    );
+                }
             }
         }
 
@@ -1691,8 +1698,12 @@ impl ProxyConfig {
                         backend.name
                     );
                 }
-                if backend.weight == 0 {
-                    anyhow::bail!("backend '{}': weight must be > 0", backend.name);
+                if backend.weight == 0 || backend.weight > 100 {
+                    anyhow::bail!(
+                        "backend '{}': weight must be 1-100, got {}",
+                        backend.name,
+                        backend.weight
+                    );
                 }
             }
         }
@@ -2564,6 +2575,58 @@ mod tests {
         let err = ProxyConfig::parse(toml).unwrap_err();
         assert!(
             format!("{err}").contains("mirror_of references unknown backend"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_reject_mirror_percent_over_100() {
+        let toml = r#"
+        [proxy]
+        name = "bad"
+        [proxy.listen]
+
+        [[backends]]
+        name = "primary"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "mirror"
+        transport = "stdio"
+        command = "echo"
+        mirror_of = "primary"
+        mirror_percent = 101
+        "#;
+        let err = ProxyConfig::parse(toml).unwrap_err();
+        assert!(
+            format!("{err}").contains("mirror_percent must be 0-100"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_reject_canary_weight_over_100() {
+        let toml = r#"
+        [proxy]
+        name = "bad"
+        [proxy.listen]
+
+        [[backends]]
+        name = "primary"
+        transport = "stdio"
+        command = "echo"
+
+        [[backends]]
+        name = "canary"
+        transport = "stdio"
+        command = "echo"
+        canary_of = "primary"
+        weight = 101
+        "#;
+        let err = ProxyConfig::parse(toml).unwrap_err();
+        assert!(
+            format!("{err}").contains("weight must be 1-100"),
             "unexpected error: {err}"
         );
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -980,7 +980,7 @@ mod config_tests {
         weight = 0
         "#;
         let err = ProxyConfig::parse(toml).unwrap_err();
-        assert!(err.to_string().contains("weight must be > 0"));
+        assert!(err.to_string().contains("weight must be 1-100"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Validation rejects `weight == 0` for canary backends but has no upper bound, and `mirror_percent` has no bounds check at all, despite both being documented as percentages (1-100 and 0-100). Found by the #213 property tests.

## Plan

1. Reject `weight > 100` in the `canary_of` validation block, beside the existing zero check.
2. Reject `mirror_percent > 100` in the `mirror_of` validation block.
3. Example-based unit tests beside the existing rejection tests. The generative regression lands with #213 (PR #225).

Closes #226.