### PR TITLE
bench: add an end-to-end HTTP overhead benchmark with a documented baseline (closes #210)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,90 @@
+# Benchmarks
+
+Two harnesses answer two different questions. Neither runs in CI; both are
+reproducible locally.
+
+## End-to-end HTTP overhead
+
+**Question:** what does putting mcp-proxy in front of a backend cost, over
+real HTTP, with protocol-correct MCP clients?
+
+```bash
+cargo run --release --example overhead
+```
+
+[`examples/overhead.rs`](../examples/overhead.rs) starts a tower-mcp HTTP
+backend (an echo tool) on an ephemeral loopback port and mcp-proxy in front
+of it twice: a minimal config with no middleware, and a loaded config with
+timeout, retry, circuit breaker, response cache, and request coalescing. It
+then drives three scenarios (direct to the backend, through the minimal
+proxy, through the loaded proxy) with `McpClient` workers at 1, 8, and 32
+concurrent sessions, 2000 requests per cell after warmup.
+
+Methodology notes:
+
+- Every request carries distinct arguments, so the cache and coalescer on
+  the loaded proxy cannot short-circuit the measurement; the loaded numbers
+  pay the full middleware traversal cost.
+- Workers establish and settle their sessions before a barrier; timing
+  starts after it, so throughput measures steady state rather than
+  connection storms.
+- Latency percentiles come from per-request wall clock on the client side.
+
+### Baseline
+
+Apple M4 Pro (14 cores, 24 GB), macOS 26.6, rustc 1.97.1, release profile,
+loopback HTTP. mcp-proxy v0.4.1 working tree, 2026-08-04:
+
+```text
+scenario         conc      req/s        p50        p95        p99   resets
+direct              1      17596    50.12us    89.21us   113.54us        0
+direct              8      63924   112.58us   143.12us   162.67us        0
+direct             32      86951   266.12us   397.17us   482.00us        0
+proxied-minimal     1       9551   102.04us   116.46us   137.46us        0
+proxied-minimal     8      33489   218.33us   260.42us   281.17us        0
+proxied-minimal    32      35113   601.46us   736.79us   808.96us        1
+proxied-loaded      1       9153   106.88us   122.46us   149.29us        0
+proxied-loaded      8      33113   217.25us   265.29us   284.00us        0
+proxied-loaded     32      31518   616.08us   778.79us   822.00us        2
+```
+
+How to read it:
+
+- The proxy adds roughly 50us to p50 at low concurrency: one additional
+  HTTP hop, session lookup, and namespace routing. Against a loopback echo
+  backend that roughly halves throughput; against any real backend doing
+  real work, 50us disappears into the noise. This echo setup is the worst
+  case for relative overhead by construction.
+- The full resilience and caching stack costs about 5us p50 over the
+  minimal proxy (compare proxied-loaded to proxied-minimal). The middleware
+  chain is cheap relative to the hop itself.
+- The `resets` column counts sessions that had to reconnect before
+  becoming usable. Nonzero values at 32 concurrent sessions reflect a known
+  tower-mcp HTTP transport issue where the `notifications/initialized`
+  notification can be lost under concurrent session creation
+  (joshrotenberg/tower-mcp#1174); the harness reconnects the way a real
+  client would and reports the count.
+
+Numbers vary run to run by a few percent; treat them as scale, not truth.
+
+## Per-middleware overhead (criterion)
+
+**Question:** what does each middleware layer cost in isolation, without
+HTTP?
+
+```bash
+cargo bench
+```
+
+[`benches/proxy_overhead.rs`](../benches/proxy_overhead.rs) measures
+per-request latency through in-process `ChannelTransport` backends with
+individual middleware configurations (cache, filter, validation), isolating
+layer cost from transport cost. Criterion writes reports to
+`target/criterion/`.
+
+## Ground rules
+
+Performance claims in the README or comparison docs must cite one of these
+harnesses and be reproducible with a single command. No cross-proxy
+comparative numbers: environments and feature sets differ too much for a
+one-line comparison to inform anyone.

--- a/examples/overhead.rs
+++ b/examples/overhead.rs
@@ -1,0 +1,242 @@
+//! End-to-end HTTP overhead benchmark harness.
+//!
+//! Measures what putting mcp-proxy in front of a backend costs, over real
+//! HTTP on loopback, with protocol-correct MCP clients:
+//!
+//! 1. `direct`: client -> backend
+//! 2. `proxied-minimal`: client -> mcp-proxy (no middleware) -> backend
+//! 3. `proxied-loaded`: client -> mcp-proxy (timeout, retry, circuit
+//!    breaker, cache, coalescing) -> backend
+//!
+//! Each scenario runs at several concurrency levels; every request carries
+//! distinct arguments so caching and coalescing cannot short-circuit the
+//! measurement. Methodology and baseline numbers: docs/benchmarks.md.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --release --example overhead
+//! ```
+
+use std::time::{Duration, Instant};
+
+use tower_mcp::client::{HttpClientTransport, McpClient};
+use tower_mcp::transport::http::HttpTransport;
+use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+
+use mcp_proxy::{Proxy, ProxyConfig};
+
+const WARMUP_PER_WORKER: usize = 20;
+const REQUESTS_PER_CELL: usize = 2000;
+const CONCURRENCY_LEVELS: &[usize] = &[1, 8, 32];
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct EchoInput {
+    v: u64,
+}
+
+fn echo_router() -> McpRouter {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a number")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.v.to_string())) })
+        .build();
+    McpRouter::new()
+        .server_info("bench-backend", "1.0.0")
+        .tool(echo)
+}
+
+/// Serve an axum router on an ephemeral loopback port; returns the base URL.
+async fn serve(router: axum::Router) -> anyhow::Result<String> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("server runs");
+    });
+    Ok(format!("http://{addr}"))
+}
+
+async fn start_backend() -> anyhow::Result<String> {
+    serve(HttpTransport::new(echo_router()).into_router()).await
+}
+
+async fn start_proxy(backend_url: &str, loaded: bool) -> anyhow::Result<String> {
+    let middleware = if loaded {
+        r#"
+[backends.timeout]
+seconds = 5
+
+[backends.retry]
+max_retries = 2
+initial_backoff_ms = 10
+max_backoff_ms = 100
+
+[backends.circuit_breaker]
+failure_rate_threshold = 0.5
+minimum_calls = 100
+wait_duration_seconds = 5
+
+[backends.cache]
+tool_ttl_seconds = 60
+max_entries = 10000
+"#
+    } else {
+        ""
+    };
+    let toml = format!(
+        r#"
+[proxy]
+name = "bench-proxy"
+[proxy.listen]
+host = "127.0.0.1"
+port = 0
+
+[performance]
+coalesce_requests = {coalesce}
+
+[[backends]]
+name = "b"
+transport = "http"
+url = "{backend_url}"
+{middleware}
+"#,
+        coalesce = loaded,
+    );
+    let config = ProxyConfig::parse(&toml)?;
+    let proxy = Proxy::from_config(config).await?;
+    let (router, _session_handle) = proxy.into_router();
+    serve(router).await
+}
+
+/// The tool name differs by target: the backend exposes `echo`, the proxy
+/// namespaces it as `b/echo`.
+async fn run_cell(
+    url: &str,
+    tool: &str,
+    concurrency: usize,
+) -> anyhow::Result<(Duration, Vec<Duration>, usize)> {
+    let per_worker = REQUESTS_PER_CELL / concurrency;
+    // Workers settle their sessions first and rendezvous at the barrier, so
+    // throughput measures steady state, not session-establishment storms
+    // (those show up in the resets column instead).
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(concurrency + 1));
+    let mut handles = Vec::new();
+    for worker in 0..concurrency {
+        let url = url.to_string();
+        let tool = tool.to_string();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            // Under concurrent session creation the initialized notification
+            // can be lost and the session stranded (tower-mcp#1174); connect
+            // like a real client would: settle the session or reconnect.
+            // Reconnects are counted and reported.
+            let mut reconnects = 0usize;
+            let client = 'connect: loop {
+                let client = McpClient::connect(HttpClientTransport::new(&url))
+                    .await
+                    .expect("client connects");
+                client
+                    .initialize("bench-client", "1.0.0")
+                    .await
+                    .expect("initialize");
+                for _ in 0..20 {
+                    if client.list_tools().await.is_ok() {
+                        break 'connect client;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                reconnects += 1;
+                assert!(
+                    reconnects <= 5,
+                    "worker {worker}: session never settled after 5 connects"
+                );
+            };
+            barrier.wait().await;
+            let mut latencies = Vec::with_capacity(per_worker);
+            let mut handshake_retries = 0usize;
+            for i in 0..(WARMUP_PER_WORKER + per_worker) {
+                let arg = (worker * 1_000_000 + i) as u64;
+                let t = Instant::now();
+                let mut attempts = 0;
+                let result = loop {
+                    attempts += 1;
+                    match client
+                        .call_tool(&tool, serde_json::json!({ "v": arg }))
+                        .await
+                    {
+                        Ok(r) => break r,
+                        // The initialized-notification race (tower-mcp#1174)
+                        // can also surface under load; count and retry it so
+                        // the run completes AND quantifies the rate.
+                        Err(e)
+                            if attempts <= 10
+                                && e.to_string().contains("notifications/initialized") =>
+                        {
+                            handshake_retries += 1;
+                            tokio::time::sleep(Duration::from_millis(10)).await;
+                        }
+                        Err(e) => panic!("call failed: {e}"),
+                    }
+                };
+                let elapsed = t.elapsed();
+                assert!(!result.is_error, "echo must not fail");
+                if i >= WARMUP_PER_WORKER {
+                    latencies.push(elapsed);
+                }
+            }
+            (latencies, handshake_retries + reconnects)
+        }));
+    }
+    barrier.wait().await;
+    let started = Instant::now();
+    let mut all = Vec::with_capacity(REQUESTS_PER_CELL);
+    let mut retries = 0usize;
+    for h in handles {
+        let (latencies, worker_retries) = h.await?;
+        all.extend(latencies);
+        retries += worker_retries;
+    }
+    let elapsed = started.elapsed();
+    all.sort();
+    Ok((elapsed, all, retries))
+}
+
+fn pct(sorted: &[Duration], p: f64) -> Duration {
+    let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[idx]
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let backend_url = start_backend().await?;
+    let minimal_url = start_proxy(&backend_url, false).await?;
+    let loaded_url = start_proxy(&backend_url, true).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let scenarios: &[(&str, &str, &str)] = &[
+        ("direct", backend_url.as_str(), "echo"),
+        ("proxied-minimal", minimal_url.as_str(), "b/echo"),
+        ("proxied-loaded", loaded_url.as_str(), "b/echo"),
+    ];
+
+    println!(
+        "{:<16} {:>4} {:>10} {:>10} {:>10} {:>10} {:>8}",
+        "scenario", "conc", "req/s", "p50", "p95", "p99", "resets"
+    );
+    for (name, url, tool) in scenarios {
+        for &concurrency in CONCURRENCY_LEVELS {
+            let (elapsed, latencies, retries) = run_cell(url, tool, concurrency).await?;
+            let throughput = latencies.len() as f64 / elapsed.as_secs_f64();
+            println!(
+                "{:<16} {:>4} {:>10.0} {:>10.2?} {:>10.2?} {:>10.2?} {:>8}",
+                name,
+                concurrency,
+                throughput,
+                pct(&latencies, 0.50),
+                pct(&latencies, 0.95),
+                pct(&latencies, 0.99),
+                retries,
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Context

`benches/proxy_overhead.rs` measures per-middleware overhead in-process; nothing answered the end-to-end question "what does putting mcp-proxy in front of a backend cost over HTTP." This PR creates that benchmark and documents a reproducible baseline.

## What landed

- `examples/overhead.rs`: self-contained harness. Starts a tower-mcp HTTP echo backend and two proxies in front of it (minimal config; loaded config with timeout, retry, circuit breaker, cache, coalescing), then drives direct / proxied-minimal / proxied-loaded scenarios with protocol-correct `McpClient` workers at 1, 8, and 32 concurrent sessions. Distinct arguments per request keep the cache and coalescer honest; a barrier separates session establishment from steady-state timing; session reconnects are counted and reported.
- `docs/benchmarks.md`: methodology, how to run both harnesses, baseline from a named machine, and ground rules (performance claims must cite a harness; no cross-proxy numbers).

## Baseline (Apple M4 Pro, loopback, release)

```text
scenario         conc      req/s        p50
direct              1      17596    50.12us
proxied-minimal     1       9551   102.04us
proxied-loaded      1       9153   106.88us
direct             32      86951   266.12us
proxied-minimal    32      35113   601.46us
proxied-loaded     32      31518   616.08us
```

The proxy hop costs ~50us p50 against a loopback echo backend (the worst case for relative overhead by construction); the full resilience and caching stack adds only ~5us over the minimal proxy.

## Found along the way

Under concurrent session creation the `notifications/initialized` notification can be permanently lost, stranding sessions until reconnect. Reproduced against plain tower-mcp HTTP servers with no proxy involved; reported with evidence as joshrotenberg/tower-mcp#1174. The harness reconnects the way a real client would and reports the count in the `resets` column.

## Verification

`cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings` at default, `--no-default-features`, `--all-features`: all green. The harness runs in a few seconds.

Closes #210.