### PR TITLE
fix: reject websocket transport at parse time without the feature (closes #229)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1708,6 +1708,21 @@ impl ProxyConfig {
             }
         }
 
+        // Validate websocket transport requires the websocket feature, so
+        // --check predicts the startup failure instead of passing configs
+        // the binary will refuse to run (#229). Startup keeps its own bail
+        // as a second line of defense.
+        #[cfg(not(feature = "websocket"))]
+        for backend in &self.backends {
+            if matches!(backend.transport, TransportType::Websocket) {
+                anyhow::bail!(
+                    "backend '{}': transport = \"websocket\" requires the 'websocket' feature. \
+                     Rebuild with: cargo install mcp-proxy --features websocket",
+                    backend.name
+                );
+            }
+        }
+
         // Validate tool_exposure = "search" requires the discovery feature
         #[cfg(not(feature = "discovery"))]
         if self.proxy.tool_exposure == ToolExposure::Search {
@@ -3318,6 +3333,25 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "websocket"))]
+    const WEBSOCKET_BACKEND_CONFIG: &str = r#"
+        [proxy]
+        name = "test"
+        [proxy.listen]
+
+        [[backends]]
+        name = "ws"
+        transport = "websocket"
+        url = "ws://localhost:9000"
+        "#;
+
+    #[cfg(not(feature = "websocket"))]
+    #[test]
+    fn test_websocket_transport_rejected_without_feature() {
+        let err = ProxyConfig::parse(WEBSOCKET_BACKEND_CONFIG).unwrap_err();
+        assert!(err.to_string().contains("requires the 'websocket' feature"));
+    }
+
     #[test]
     fn test_parse_bearer_scoped_tokens() {
         let toml = r#"
@@ -3471,6 +3505,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "websocket")]
     #[test]
     fn test_parse_websocket_transport() {
         let toml = r#"
@@ -3515,6 +3550,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "websocket")]
     #[test]
     fn test_websocket_with_bearer_token() {
         let toml = r#"


### PR DESCRIPTION
## Context

`--check` approves configs with `transport = "websocket"` in builds without the `websocket` feature; the same config then fails at startup when `build_mcp_proxy` reaches the backend. The other feature-gated surfaces (`redis-cache`, `sqlite-cache`, `discovery`) validate at parse time, so `--check`-based deploy gates get a false pass for websocket only.

## Plan

1. Add the parse-time check in `ProxyConfig` validation beside the other feature-conditional checks: reject websocket backends when the feature is compiled out, with the same "requires the 'websocket' feature" wording the startup path uses (which also keeps the examples guard test's feature-skip pattern working for `examples/websocket-backend.toml`).
2. Keep the startup bail in src/proxy.rs as a second line of defense.
3. Test pair following the #203 pattern: success path gated on `websocket`, rejection twin gated on `not(websocket)`.
4. Verify at all three feature points.

Closes #229.