### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.4] - 2026-08-14
+
+### Miscellaneous Tasks
+
+- Bump tower-mcp and tower-mcp-types to 0.22.0 ([#233](https://github.com/joshrotenberg/mcp-proxy/pull/233))
+
+
+
 ## [0.4.3] - 2026-08-05
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-proxy"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-proxy"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.90"
 description = "Tower-native MCP gateway for aggregating backends with auth, resilience, and observability"


### PR DESCRIPTION



## 🤖 New release

* `mcp-proxy`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4] - 2026-08-14

### Miscellaneous Tasks

- Bump tower-mcp and tower-mcp-types to 0.22.0 ([#233](https://github.com/joshrotenberg/mcp-proxy/pull/233))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).