### PR TITLE
feat: custom outbound headers for HTTP backends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -186,6 +186,7 @@ impl ProxyBuilder {
             command: None,
             url: Some(url.into()),
             bearer_token: Some(token.into()),
+            headers: std::collections::HashMap::new(),
             ..default_backend()
         });
         self
@@ -494,6 +495,7 @@ fn default_backend() -> BackendConfig {
         url: None,
         env: HashMap::new(),
         bearer_token: None,
+        headers: std::collections::HashMap::new(),
         forward_auth: false,
         timeout: None,
         circuit_breaker: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@
 //! transport = "http"
 //! url = "http://mcp-server:8080"
 //! bearer_token = "${API_TOKEN}"    # ${VAR} syntax for env vars
+//! headers = { "X-API-Key" = "${API_KEY}", "X-Tenant" = "acme" }  # custom outbound headers
 //! forward_auth = true              # Forward client's auth token
 //!
 //! # WebSocket server
@@ -428,6 +429,11 @@ pub struct BackendConfig {
     /// Static bearer token for authenticating to this backend (HTTP only).
     /// Supports `${ENV_VAR}` syntax for env var resolution.
     pub bearer_token: Option<String>,
+    /// Custom headers sent on every request to this backend (HTTP/WebSocket only).
+    /// Values support `${ENV_VAR}` syntax for env var resolution.
+    /// An explicit `Authorization` header takes precedence over `bearer_token`.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
     /// Forward the client's inbound auth token to this backend.
     /// Only works with HTTP backends when the proxy has auth enabled.
     #[serde(default)]
@@ -1798,6 +1804,13 @@ impl ProxyConfig {
             {
                 *token = env_val;
             }
+            for value in backend.headers.values_mut() {
+                if let Some(var_name) = value.strip_prefix("${").and_then(|s| s.strip_suffix('}'))
+                    && let Ok(env_val) = std::env::var(var_name)
+                {
+                    *value = env_val;
+                }
+            }
         }
 
         // Resolve env vars in auth config
@@ -1890,6 +1903,15 @@ impl ProxyConfig {
                     "backend '{}': bearer_token references unset env var '{}'",
                     backend.name, var
                 ));
+            }
+            // backend.headers values
+            for (key, value) in &backend.headers {
+                if let Some(var) = is_unset_env_ref(value) {
+                    warnings.push(format!(
+                        "backend '{}': headers.{} references unset env var '{}'",
+                        backend.name, key, var
+                    ));
+                }
             }
             // backend.env values
             for (key, value) in &backend.env {
@@ -2409,6 +2431,74 @@ mod tests {
 
         // SAFETY: same as above
         unsafe { std::env::remove_var("MCP_GW_TEST_TOKEN") };
+    }
+
+    #[test]
+    fn test_parse_backend_headers() {
+        let toml = r#"
+        [proxy]
+        name = "hdr-gw"
+        [proxy.listen]
+
+        [[backends]]
+        name = "signoz"
+        transport = "http"
+        url = "http://localhost:3000"
+        bearer_token = "tok"
+
+        [backends.headers]
+        "X-API-Key" = "key123"
+        "X-Tenant" = "acme"
+        "#;
+
+        let config = ProxyConfig::parse(toml).unwrap();
+        let headers = &config.backends[0].headers;
+        assert_eq!(headers.get("X-API-Key").map(String::as_str), Some("key123"));
+        assert_eq!(headers.get("X-Tenant").map(String::as_str), Some("acme"));
+        assert!(config.backends[0].bearer_token.is_some());
+        // backends without a headers block default to empty
+        let empty = ProxyConfig::parse(
+            r#"
+        [proxy]
+        name = "g"
+        [proxy.listen]
+
+        [[backends]]
+        name = "db"
+        transport = "http"
+        url = "http://localhost:1"
+        "#,
+        )
+        .unwrap();
+        assert!(empty.backends[0].headers.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_headers_env_var() {
+        unsafe { std::env::set_var("MCP_GW_TEST_HEADER", "resolved-value") };
+        let toml = r#"
+        [proxy]
+        name = "hdr-env-gw"
+        [proxy.listen]
+
+        [[backends]]
+        name = "signoz"
+        transport = "http"
+        url = "http://localhost:3000"
+
+        [backends.headers]
+        "X-API-Key" = "${MCP_GW_TEST_HEADER}"
+        "X-Literal" = "plain"
+        "#;
+        let mut config = ProxyConfig::parse(toml).unwrap();
+        config.resolve_env_vars();
+        unsafe { std::env::remove_var("MCP_GW_TEST_HEADER") };
+        let headers = &config.backends[0].headers;
+        assert_eq!(
+            headers.get("X-API-Key").map(String::as_str),
+            Some("resolved-value")
+        );
+        assert_eq!(headers.get("X-Literal").map(String::as_str), Some("plain"));
     }
 
     #[test]

--- a/src/mcp_json.rs
+++ b/src/mcp_json.rs
@@ -105,6 +105,7 @@ fn server_to_backend(name: String, server: McpJsonServer) -> Result<BackendConfi
         url,
         env: server.env,
         bearer_token: None,
+        headers: std::collections::HashMap::new(),
         forward_auth: false,
         timeout: None,
         circuit_breaker: None,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -410,6 +410,9 @@ async fn build_mcp_proxy(config: &ProxyConfig) -> Result<(McpProxy, HashMap<Stri
                 if let Some(token) = &backend.bearer_token {
                     transport = transport.bearer_token(token);
                 }
+                for (name, value) in &backend.headers {
+                    transport = transport.header(name, value);
+                }
 
                 builder = builder.backend(&backend.name, transport).await;
             }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -249,6 +249,9 @@ async fn add_backend(proxy: &McpProxy, backend: &BackendConfig) -> anyhow::Resul
             if let Some(token) = &backend.bearer_token {
                 transport = transport.bearer_token(token);
             }
+            for (name, value) in &backend.headers {
+                transport = transport.header(name, value);
+            }
 
             if has_middleware {
                 let layer = build_backend_layer(backend);


### PR DESCRIPTION
Closes #237.

## What

Adds a per-backend `headers` map for HTTP backends — custom headers sent on every outbound request (initialize, notifications, tools/call, resources/list, prompts/list):

```toml
[[backends]]
name = "signoz"
transport = "http"
url = "https://mcp.us.signoz.cloud/mcp"
bearer_token = "${SIGNOZ_API_KEY}"

[backends.headers]
"SIGNOZ-API-KEY" = "${SIGNOZ_API_KEY}"
"X-SigNoz-URL" = "${SIGNOZ_URL}"
```

- Values support `${ENV_VAR}` expansion, same as `bearer_token`
- An explicit `Authorization` header takes precedence over `bearer_token` (covers non-Bearer schemes too)
- `--check` warns when a header value references an unset env var
- Applied on both initial construction (proxy.rs) and hot-reload backend replacement (reload.rs)
- `builder.rs` / `mcp_json.rs` construct backends with an empty header map

## Why

Many hosted MCP servers authenticate with custom headers instead of (or alongside) a bearer token — the `X-API-Key` pattern is common across the ecosystem. SigNoz's hosted MCP, for example, requires `SIGNOZ-API-KEY` + `X-SigNoz-URL` and rejects Bearer-only auth; without this, such backends need a local header-injecting reverse proxy in front of them (which is what I was doing before this PR).

## Verification

- Header-capturing test backend: literal and env-expanded headers arrive on every request type, coexisting with `bearer_token`.
- Real-world: SigNoz hosted MCP backend now initializes natively (43 tools) and `tools/call` returns live data with `bearer_token` + two custom headers — no shim.
- `cargo test --release`: full suite green, plus two new tests (`test_parse_backend_headers`, `test_resolve_headers_env_var`) covering parsing and env resolution.

## Notes / follow-ups

- WebSocket transport still supports only `bearer_token`; headers are HTTP-only for now (documented on the field). Happy to extend `ws_transport` if there's interest.
- `admin.rs` dynamic backend addition (`proxy/add_backend`) doesn't accept headers yet either — config-file backends only.