### PR TITLE
feat(discovery): proxy/get_tool meta-tool exposing tool input schemas

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -83,7 +83,10 @@ pub type SharedDiscoveryIndex = Arc<RwLock<DiscoveryRegistry>>;
 ///
 /// Sends a `ListTools` request through the proxy to collect all registered
 /// tools, then indexes them using jpx-engine's BM25 search.
-pub async fn build_index(proxy: &mut McpProxy, separator: &str) -> SharedDiscoveryIndex {
+pub async fn build_index(
+    proxy: &mut McpProxy,
+    separator: &str,
+) -> (SharedDiscoveryIndex, SchemaStore) {
     use tower::Service;
     use tower_mcp::protocol::{ListToolsParams, McpRequest, McpResponse, RequestId};
     use tower_mcp::router::{Extensions, RouterRequest};
@@ -108,16 +111,21 @@ pub async fn build_index(proxy: &mut McpProxy, separator: &str) -> SharedDiscove
     let mut registry = DiscoveryRegistry::new();
     index_tools(&mut registry, &tools, separator);
 
+    let schemas = SchemaStore::new();
+    for tool in &tools {
+        schemas.insert(tool.name.replace(separator, ":"), tool.input_schema.clone()).await;
+    }
+
     tracing::info!(tools_indexed = tools.len(), "Built tool discovery index");
 
-    Arc::new(RwLock::new(registry))
+    (Arc::new(RwLock::new(registry)), schemas)
 }
 
 /// Re-index all tools into an existing shared discovery index.
 ///
 /// Called after hot reload adds, removes, or replaces backends to keep
 /// the search index in sync with the proxy's current tool set.
-pub async fn reindex(index: &SharedDiscoveryIndex, proxy: &mut McpProxy, separator: &str) {
+pub async fn reindex(index: &SharedDiscoveryIndex, schemas: &SchemaStore, proxy: &mut McpProxy, separator: &str) {
     use tower::Service;
     use tower_mcp::protocol::{ListToolsParams, McpRequest, McpResponse, RequestId};
     use tower_mcp::router::{Extensions, RouterRequest};
@@ -138,6 +146,13 @@ pub async fn reindex(index: &SharedDiscoveryIndex, proxy: &mut McpProxy, separat
 
     let mut registry = DiscoveryRegistry::new();
     index_tools(&mut registry, &tools, separator);
+    {
+        let mut store = schemas.0.write().await;
+        store.clear();
+        for tool in &tools {
+            store.insert(tool.name.replace(separator, ":"), tool.input_schema.clone());
+        }
+    }
 
     let mut guard = index.write().await;
     *guard = registry;
@@ -281,6 +296,12 @@ fn default_top_k() -> usize {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct GetToolInput {
+    /// Tool ID from a search_tools/similar_tools result (e.g. "signoz:signoz_query_metrics")
+    tool_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct SimilarInput {
     /// Tool ID to find similar tools for (e.g. "math:add")
     tool_id: String,
@@ -325,7 +346,31 @@ struct CategoriesResult {
 }
 
 /// Build the discovery tools and return them for inclusion in the admin router.
+/// Sidecar map of tool id ("server:tool") -> original input JSON Schema,
+/// populated at index build/reindex time and exposed via `proxy/get_tool`.
+#[derive(Clone, Default)]
+pub struct SchemaStore(pub std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<String, serde_json::Value>>>);
+
+impl SchemaStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub async fn insert(&self, id: String, schema: serde_json::Value) {
+        self.0.write().await.insert(id, schema);
+    }
+    pub async fn get(&self, id: &str) -> Option<serde_json::Value> {
+        self.0.read().await.get(id).cloned()
+    }
+}
+
 pub fn build_discovery_tools(index: SharedDiscoveryIndex) -> Vec<tower_mcp::Tool> {
+    build_discovery_tools_with_schemas(index, SchemaStore::new())
+}
+
+pub fn build_discovery_tools_with_schemas(
+    index: SharedDiscoveryIndex,
+    schemas: SchemaStore,
+) -> Vec<tower_mcp::Tool> {
     let index_for_search = Arc::clone(&index);
     let search_tools = ToolBuilder::new("search_tools")
         .description(
@@ -342,6 +387,35 @@ pub fn build_discovery_tools(index: SharedDiscoveryIndex) -> Vec<tower_mcp::Tool
                 Ok(CallToolResult::text(
                     serde_json::to_string_pretty(&entries).unwrap(),
                 ))
+            }
+        })
+        .build();
+
+    let schemas_for_get = schemas.clone();
+    let get_tool = ToolBuilder::new("get_tool")
+        .description(
+            "Get the full input JSON Schema and description for a tool by its id \
+             (e.g. \"signoz:signoz_query_metrics\"). Call this after search_tools \
+             before invoking an unfamiliar tool through proxy/call_tool.",
+        )
+        .handler(move |input: GetToolInput| {
+            let store = schemas_for_get.clone();
+            async move {
+                match store.get(&input.tool_id).await {
+                    Some(schema) => {
+                        let out = serde_json::json!({
+                            "id": input.tool_id,
+                            "input_schema": schema,
+                        });
+                        Ok(CallToolResult::text(
+                            serde_json::to_string_pretty(&out).unwrap(),
+                        ))
+                    }
+                    None => Ok(CallToolResult::text(format!(
+                        "Unknown tool id '{}' \u{2014} run proxy/search_tools first and use its \"id\" field",
+                        input.tool_id
+                    ))),
+                }
             }
         })
         .build();
@@ -390,7 +464,7 @@ pub fn build_discovery_tools(index: SharedDiscoveryIndex) -> Vec<tower_mcp::Tool
         })
         .build();
 
-    vec![search_tools, similar_tools, tool_categories]
+    vec![search_tools, get_tool, similar_tools, tool_categories]
 }
 
 #[cfg(test)]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -35,6 +35,8 @@ pub struct Proxy {
     config: ProxyConfig,
     #[cfg(feature = "discovery")]
     discovery_index: Option<crate::discovery::SharedDiscoveryIndex>,
+    #[cfg(feature = "discovery")]
+    discovery_schemas: Option<crate::discovery::SchemaStore>,
 }
 
 impl Proxy {
@@ -117,13 +119,13 @@ impl Proxy {
         let discovery_enabled = config.proxy.tool_discovery
             || config.proxy.tool_exposure == crate::config::ToolExposure::Search;
         #[cfg(feature = "discovery")]
-        let (discovery_index, discovery_tools) = if discovery_enabled {
-            let index =
+        let (discovery_index, discovery_schemas, discovery_tools) = if discovery_enabled {
+            let (index, schemas) =
                 crate::discovery::build_index(&mut proxy_for_caller, &config.proxy.separator).await;
-            let tools = crate::discovery::build_discovery_tools(index.clone());
-            (Some(index), Some(tools))
+            let tools = crate::discovery::build_discovery_tools_with_schemas(index.clone(), schemas.clone());
+            (Some(index), Some(schemas), Some(tools))
         } else {
-            (None, None)
+            (None, None, None)
         };
         #[cfg(not(feature = "discovery"))]
         let discovery_tools: Option<Vec<tower_mcp::Tool>> = None;
@@ -150,6 +152,8 @@ impl Proxy {
             config,
             #[cfg(feature = "discovery")]
             discovery_index,
+            #[cfg(feature = "discovery")]
+            discovery_schemas,
         })
     }
 
@@ -177,7 +181,14 @@ impl Proxy {
             #[cfg(feature = "discovery")]
             self.discovery_index
                 .as_ref()
-                .map(|idx| (idx.clone(), self.config.proxy.separator.clone())),
+                .zip(self.discovery_schemas.as_ref())
+                .map(|(idx, schemas)| {
+                    (
+                        idx.clone(),
+                        schemas.clone(),
+                        self.config.proxy.separator.clone(),
+                    )
+                }),
         );
     }
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -23,6 +23,7 @@ pub fn spawn_config_watcher(
     proxy: McpProxy,
     #[cfg(feature = "discovery")] discovery_index: Option<(
         crate::discovery::SharedDiscoveryIndex,
+        crate::discovery::SchemaStore,
         String,
     )>,
 ) {
@@ -45,6 +46,7 @@ async fn watch_loop(
     proxy: McpProxy,
     #[cfg(feature = "discovery")] discovery_index: Option<(
         crate::discovery::SharedDiscoveryIndex,
+        crate::discovery::SchemaStore,
         String,
     )>,
 ) {
@@ -187,9 +189,9 @@ async fn watch_loop(
 
         // Re-index discovery if enabled
         #[cfg(feature = "discovery")]
-        if let Some((ref index, ref separator)) = discovery_index {
+        if let Some((ref index, ref schemas, ref separator)) = discovery_index {
             let mut proxy_clone = proxy.clone();
-            crate::discovery::reindex(index, &mut proxy_clone, separator).await;
+            crate::discovery::reindex(index, schemas, &mut proxy_clone, separator).await;
         }
     }
 }


### PR DESCRIPTION
## Problem

In `tool_exposure = "search"` mode (and generally for any tool not directly listed), clients discover tools via `proxy/search_tools` / `proxy/similar_tools` — but those return only `id`/`name`/`description`/`score`/`tags`. The tool's `input_schema` is extracted for BM25 indexing (`extract_params`) and then **discarded**.

Result: an agent that finds a tool by search has no way to learn its parameters without invoking it. In practice agents guess arguments and iterate on validation errors. I observed two real agent sessions degrade this way against SigNoz's hosted MCP (43 tools behind the proxy): the first burned 40+ tool calls on trial-and-error parameter shapes; the workaround became reading the server's MCP *resources* for docs, which only works when the backend happens to expose them.

## What

Adds a `SchemaStore` sidecar (tool id → input JSON Schema), populated during `build_index` and refreshed on hot-reload `reindex`, exposed through a new `proxy/get_tool` meta-tool:

```json
{"tool_id": "signoz:signoz_query_metrics"}
```
```json
{
  "id": "signoz:signoz_query_metrics",
  "input_schema": { "properties": { "end": {...}, "start": {...}, ... }, ... }
}
```

The discovery workflow becomes **search → get_tool(id) → call_tool** — the id comes straight from search results (same `server:tool` key format as `ToolQueryResult.id`), and no parameter guessing is ever needed. Unknown ids return a hint to run `search_tools` first.

## Implementation notes

- `SchemaStore` is a small `Arc<RwLock<HashMap<String, Value>>>` — populated in the same pass that feeds the BM25 registry, cleared + refilled on reindex.
- `build_discovery_tools_with_schemas` keeps the old `build_discovery_tools` signature as a thin wrapper (empty store) so existing callers/tests are unaffected.
- The store is threaded through `Proxy` → `spawn_config_watcher` → `watch_loop` → `reindex` (the reload watcher tuple grows from `(index, separator)` to `(index, schemas, separator)`).

## Verification

- Agent-driven end-to-end (real SigNoz backend): the same natural-language query that previously failed after 40+ trial-and-error calls now resolves in three meta-tool calls — search, get_tool, call_tool — returning correct per-pod metrics with properly bound `groupBy`/`startTime`/`endTime` arguments taken from the schema.
- `cargo test --release`: full suite green.

## Alternative considered: inline schemas in search results

The schema could instead be embedded directly in `search_tools`/`similar_tools` results (one call instead of two). I considered it and went with `get_tool` for two reasons:

1. **The index doesn't retain the raw schema.** `extract_params` reduces `input_schema` to compact `ParamSpec`s (name/type/required — enums dropped, nested structure gone) purely for BM25 scoring. Inline delivery would still need the raw schema retained in a sidecar — which is exactly what `SchemaStore` is. So the storage change is identical either way; only delivery differs.
2. **Context economy.** Full schemas are heavy (~2KB for a metrics query tool; ×10 results ×repeat searches adds up fast). Search-exposure mode exists to keep tool payloads out of context until needed — embedding schemas in every search response partially undoes that. A targeted `get_tool(id)` fetch for the one tool about to be called costs one extra round-trip (~200ms) and nothing on repeated searches.

A reasonable middle ground, if preferred: inline the compact `ParamSpec` list in search results (enough to make a correct call in one hop) and keep `get_tool` for full-fidelity schemas. Happy to amend either way.
